### PR TITLE
feature/urauth-tree-enhancement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7383,7 +7383,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-urauth"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ada-url",
  "addr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,26 +13,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ada-url"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef667a8b52aca2f70b570309cb9fde2d715c9c387e3c80b53df05c87d47ff10"
-dependencies = [
- "cc",
- "derive_more",
- "link_args",
-]
-
-[[package]]
-name = "addr"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93b8a41dbe230ad5087cc721f8d41611de654542180586b315d9f4cf6b72bef"
-dependencies = [
- "psl-types",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead 0.5.2",
  "aes 0.8.3",
@@ -192,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -231,30 +211,29 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
 dependencies = [
  "utf8parse",
 ]
@@ -270,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.2"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -342,7 +321,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.27",
+ "time",
 ]
 
 [[package]]
@@ -358,7 +337,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.27",
+ "time",
 ]
 
 [[package]]
@@ -474,7 +453,7 @@ dependencies = [
  "log",
  "parking",
  "polling",
- "rustix 0.37.23",
+ "rustix 0.37.24",
  "slab",
  "socket2 0.4.9",
  "waker-fn",
@@ -497,7 +476,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -510,14 +489,14 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.12",
+ "pin-project-lite 0.2.13",
 ]
 
 [[package]]
 name = "atomic-waker"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -547,7 +526,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.32.0",
+ "object 0.32.1",
  "rustc-demangle",
 ]
 
@@ -577,9 +556,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "base64ct"
@@ -669,38 +648,37 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
+checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.4",
- "constant_time_eq 0.2.6",
+ "constant_time_eq",
 ]
 
 [[package]]
 name = "blake2s_simd"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
+checksum = "94230421e395b9920d23df13ea5d77a20e1725331f90fbbf6df6040b33f756ae"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.4",
- "constant_time_eq 0.2.6",
+ "constant_time_eq",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199c42ab6972d92c9f8995f086273d25c42fc0f7b2a1fcefba465c1352d25ba5"
+checksum = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.4",
  "cc",
  "cfg-if",
- "constant_time_eq 0.3.0",
- "digest 0.10.7",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -760,9 +738,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bounded-collections"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b05133427c07c4776906f673ccf36c21b102c9829c641a5b56bd151d44fd6"
+checksum = "ca548b6163b872067dc5eb82fd130c56881435e30367d2073594a3d9744120dd"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -787,9 +765,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
 dependencies = [
  "memchr",
  "serde",
@@ -806,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-slice-cast"
@@ -824,21 +802,21 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "bzip2-sys"
@@ -862,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
+checksum = "12024c4645c97566567129c204f65d5815a8c9aecf30fcbe682b2fe034996d36"
 dependencies = [
  "serde",
 ]
@@ -877,7 +855,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.18",
+ "semver 1.0.20",
  "serde",
  "serde_json",
  "thiserror",
@@ -961,17 +939,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1037,20 +1014,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.23"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.23"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1060,27 +1036,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "coarsetime"
-version = "0.1.23"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90d114103adbc625300f346d4d09dfb4ab1c4a8df6868435dd903392ecf4354"
+checksum = "a73ef0d00d14301df35d0f13f5ea32344de6b00837485c358458f1e7f2d27db4"
 dependencies = [
  "libc",
  "once_cell",
@@ -1117,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+checksum = "f057a694a54f12365049b0958a1685bb52d567f5593b355fbf685838e873d400"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1129,12 +1105,6 @@ name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
 
 [[package]]
 name = "constant_time_eq"
@@ -1293,7 +1263,7 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "itertools",
+ "itertools 0.10.5",
  "log",
  "smallvec",
  "wasmparser",
@@ -1322,16 +1292,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1988,15 +1948,16 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
+ "digest 0.10.7",
  "fiat-crypto",
- "platforms 3.0.2",
+ "platforms 3.1.2",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -2010,14 +1971,14 @@ checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "cxx"
-version = "1.0.106"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28403c86fc49e3401fdf45499ba37fad6493d9329449d6449d7f0e10f4654d28"
+checksum = "292b4841d939b20ba44fff686a35808b0ab31a3256e3629917d9aedd43eb7b3a"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -2027,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.106"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78da94fef01786dc3e0c76eafcd187abcaa9972c78e05ff4041e24fdf059c285"
+checksum = "8e7e35cf85fd4e90dcaba251f3ee95e08fb6f9d66e5c0588816f16a6ab939b40"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -2037,24 +1998,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.106"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a6f5e1dfb4b34292ad4ea1facbfdaa1824705b231610087b00b17008641809"
+checksum = "d7030aff1908ba2b7eb639466df50792b2a3fdf02bea9557c4ee1a531975554b"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.106"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c49547d73ba8dcfd4ad7325d64c6d5391ff4224d498fc39a6f3f49825a530d"
+checksum = "79418ecb0c2322a7926a5fa5a9660535432b5b3588b947e1eb484cc509edbe3c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2126,6 +2087,16 @@ checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
  "zeroize",
 ]
 
@@ -2313,7 +2284,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2357,9 +2328,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfc4744c1b8f2a09adc0e55242f60b1af195d88596bd8700be74418c056c555"
+checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
 
 [[package]]
 name = "ecdsa"
@@ -2367,10 +2338,10 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der",
+ "der 0.6.1",
  "elliptic-curve",
  "rfc6979",
- "signature",
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -2379,7 +2350,17 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "signature",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature 2.1.0",
 ]
 
 [[package]]
@@ -2389,10 +2370,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek 3.2.0",
- "ed25519",
+ "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
+dependencies = [
+ "curve25519-dalek 4.1.1",
+ "ed25519 2.2.2",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.8",
  "zeroize",
 ]
 
@@ -2424,14 +2419,14 @@ checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "der",
+ "der 0.6.1",
  "digest 0.10.7",
  "ff",
  "generic-array 0.14.7",
  "group",
  "hkdf",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.9.0",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -2452,33 +2447,33 @@ dependencies = [
 
 [[package]]
 name = "enumflags2"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c041f5090df68b32bcd905365fd51769c8b9d553fe87fde0b683534f10c01bd2"
+checksum = "5998b4f30320c9d93aed72f63af821bfdac50465b75428fce77b48ec482c3939"
 dependencies = [
  "enumflags2_derive",
 ]
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745"
+checksum = "f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "enumn"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b893c4eb2dc092c811165f84dc7447fae16fb66521717968c34c509b39b1a5c5"
+checksum = "c2ad8cef1d801a4686bfd8919f0b30eac4c8e48968c437a6405ded4fb5272d2b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2522,23 +2517,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -2604,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fatality"
@@ -2654,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.20"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
 
 [[package]]
 name = "file-per-thread-logger"
@@ -2716,9 +2700,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedstr"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812b91c5a4ba0f9f567634ab68e7d8907a7fb27846a8fddbce3c2088b692c28"
+checksum = "aeb1a6a5bd9d1e67dc19aeb6ae299b34b8a80a9d1872bd667aa6551fff65ab64"
 
 [[package]]
 name = "flate2"
@@ -2809,7 +2793,7 @@ dependencies = [
  "frame-system",
  "gethostname",
  "handlebars",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "linked-hash-map",
  "log",
@@ -2956,7 +2940,7 @@ dependencies = [
  "cfg-expr",
  "derive-syn-parse",
  "frame-support-procedural-tools",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3060,7 +3044,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eeb4ed9e12f43b7fa0baae3f9cdda28352770132ef2e09a23760c29cae8bd47"
 dependencies = [
- "rustix 0.38.8",
+ "rustix 0.38.18",
  "windows-sys 0.48.0",
 ]
 
@@ -3130,7 +3114,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.12",
+ "pin-project-lite 0.2.13",
  "waker-fn",
 ]
 
@@ -3142,7 +3126,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3152,8 +3136,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2411eed028cdf8c8034eaf21f9915f956b6c3abec4d4c7949ee67f0721127bd"
 dependencies = [
  "futures-io",
- "rustls 0.20.8",
- "webpki 0.22.0",
+ "rustls 0.20.9",
+ "webpki 0.22.4",
 ]
 
 [[package]]
@@ -3187,7 +3171,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.12",
+ "pin-project-lite 0.2.13",
  "pin-utils",
  "slab",
 ]
@@ -3340,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.3.7"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c3372087601b532857d332f5957cbae686da52bb7810bf038c3e3c3cc2fa0d"
+checksum = "c39b3bc2a8f715298032cf5087e58573809374b08160aa7d750582bdb82d2683"
 dependencies = [
  "log",
  "pest",
@@ -3387,9 +3371,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 
 [[package]]
 name = "heck"
@@ -3408,9 +3392,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
@@ -3484,6 +3468,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3513,7 +3506,7 @@ checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
  "http",
- "pin-project-lite 0.2.12",
+ "pin-project-lite 0.2.13",
 ]
 
 [[package]]
@@ -3556,7 +3549,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite 0.2.12",
+ "pin-project-lite 0.2.13",
  "socket2 0.4.9",
  "tokio",
  "tower-service",
@@ -3573,10 +3566,10 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.20.8",
+ "rustls 0.20.9",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -3700,12 +3693,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
 ]
 
 [[package]]
@@ -4363,7 +4356,7 @@ dependencies = [
  "infrablockspace-node-subsystem",
  "infrablockspace-overseer",
  "infrablockspace-primitives",
- "itertools",
+ "itertools 0.10.5",
  "kvdb",
  "lru 0.9.0",
  "parity-db",
@@ -4886,7 +4879,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.3",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -4903,7 +4896,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -4921,8 +4914,8 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
- "rustix 0.38.8",
+ "hermit-abi 0.3.3",
+ "rustix 0.38.18",
  "windows-sys 0.48.0",
 ]
 
@@ -4936,6 +4929,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4943,9 +4945,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
 dependencies = [
  "libc",
 ]
@@ -4961,9 +4963,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d291e3a5818a2384645fd9756362e6d89cf0541b0b916fa7702ea4a9833608e"
+checksum = "367a292944c07385839818bb71c8d76611138e2dedb0677d035b8da21d29c78b"
 dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-proc-macros",
@@ -4975,9 +4977,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965de52763f2004bc91ac5bcec504192440f0b568a5d621c59d9dbd6f886c3fb"
+checksum = "c8b3815d9f5d5de348e5f162b316dc9cdf4548305ebb15b4eb9328e66cf27d7a"
 dependencies = [
  "futures-util",
  "http",
@@ -4988,17 +4990,17 @@ dependencies = [
  "soketto",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tracing",
- "webpki-roots",
+ "webpki-roots 0.25.2",
 ]
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e70b4439a751a5de7dd5ed55eacff78ebf4ffe0fc009cb1ebb11417f5b536b"
+checksum = "2b5dde66c53d6dcdc8caea1874a45632ec0fcf5b437789f1e45766a1512ce803"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.4",
@@ -5024,9 +5026,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa6da1e4199c10d7b1d0a6e5e8bd8e55f351163b6f4b3cbb044672a69bd4c1c"
+checksum = "44e8ab85614a08792b9bff6c8feee23be78c98d0182d4c622c05256ab553892a"
 dependencies = [
  "heck",
  "proc-macro-crate",
@@ -5037,9 +5039,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb69dad85df79527c019659a992498d03f8495390496da2f07e6c24c2b356fc"
+checksum = "cf4d945a6008c9b03db3354fb3c83ee02d2faa9f2e755ec1dfb69c3551b8f4ba"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -5059,9 +5061,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd522fe1ce3702fd94812965d7bb7a3364b1c9aba743944c5a00529aae80f8c"
+checksum = "245ba8e5aa633dd1c1e4fae72bce06e71f42d34c14a2767c6b4d173b57bee5e5"
 dependencies = [
  "anyhow",
  "beef",
@@ -5073,9 +5075,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b83daeecfc6517cfe210df24e570fb06213533dfb990318fae781f4c7119dd9"
+checksum = "4e1b3975ed5d73f456478681a417128597acd6a2487855fdb7b4a3d4d195bf5e"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
@@ -5092,7 +5094,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -5151,9 +5153,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libloading"
@@ -5167,9 +5169,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libp2p"
@@ -5213,7 +5215,7 @@ checksum = "b6a8fcd392ff67af6cc3f03b1426c41f7f26b6b9aff2dc632c1c56dd649e571f"
 dependencies = [
  "asn1_der",
  "bs58",
- "ed25519-dalek",
+ "ed25519-dalek 1.0.1",
  "either",
  "fnv",
  "futures",
@@ -5231,7 +5233,7 @@ dependencies = [
  "rand 0.8.5",
  "rw-stream-sink",
  "sec1",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "smallvec",
  "thiserror",
  "unsigned-varint",
@@ -5304,18 +5306,18 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2d584751cecb2aabaa56106be6be91338a60a0f4e420cf2af639204f596fc1"
+checksum = "276bb57e7af15d8f100d3c11cbdd32c6752b7eef4ba7a18ecf464972c07abcce"
 dependencies = [
  "bs58",
- "ed25519-dalek",
+ "ed25519-dalek 2.0.0",
  "log",
  "multiaddr 0.17.1",
  "multihash 0.17.0",
  "quick-protobuf",
  "rand 0.8.5",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "thiserror",
  "zeroize",
 ]
@@ -5340,7 +5342,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.8.5",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "smallvec",
  "thiserror",
  "uint",
@@ -5415,7 +5417,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.8.5",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "snow",
  "static_assertions",
  "thiserror",
@@ -5455,7 +5457,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "quinn-proto",
  "rand 0.8.5",
- "rustls 0.20.8",
+ "rustls 0.20.9",
  "thiserror",
  "tokio",
 ]
@@ -5538,10 +5540,10 @@ dependencies = [
  "libp2p-core 0.39.2",
  "libp2p-identity",
  "rcgen 0.10.0",
- "ring",
- "rustls 0.20.8",
+ "ring 0.16.20",
+ "rustls 0.20.9",
  "thiserror",
- "webpki 0.22.0",
+ "webpki 0.22.4",
  "x509-parser 0.14.0",
  "yasna",
 ]
@@ -5607,7 +5609,7 @@ dependencies = [
  "rw-stream-sink",
  "soketto",
  "url",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -5708,12 +5710,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "link_args"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7721e472624c9aaad27a5eb6b7c9c6045c7a396f2efb6dabaec1b640d5e89b"
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5730,9 +5726,9 @@ dependencies = [
 
 [[package]]
 name = "linregress"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de0b5f52a9f84544d268f5fabb71b38962d6aa3c6600b8bcd27d44ccf9c9c45"
+checksum = "4de04dcecc58d366391f9920245b85ffa684558a5ef6e7736e754347c3aea9c2"
 dependencies = [
  "nalgebra",
 ]
@@ -5751,9 +5747,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "lite-json"
@@ -5868,9 +5864,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
+checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -5878,26 +5874,27 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
+ "cfg-if",
  "digest 0.10.7",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memfd"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
+checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.37.23",
+ "rustix 0.38.18",
 ]
 
 [[package]]
@@ -6120,7 +6117,7 @@ dependencies = [
  "core2",
  "digest 0.10.7",
  "multihash-derive",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "sha3",
  "unsigned-varint",
 ]
@@ -6366,9 +6363,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
@@ -6379,7 +6376,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.3",
  "libc",
 ]
 
@@ -6410,9 +6407,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -6483,7 +6480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2af4dabb2286b0be0e9711d2d24e25f6217048b71210cffd3daddc3b5c84e1f"
 dependencies = [
  "expander 0.0.6",
- "itertools",
+ "itertools 0.10.5",
  "petgraph",
  "proc-macro-crate",
  "proc-macro2",
@@ -6514,7 +6511,7 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -6525,7 +6522,7 @@ checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -7385,8 +7382,6 @@ dependencies = [
 name = "pallet-urauth"
 version = "0.1.1"
 dependencies = [
- "ada-url",
- "addr",
  "bs58",
  "fixedstr",
  "frame-benchmarking",
@@ -7681,9 +7676,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f19d20a0d2cc52327a88d131fa1c4ea81ea4a04714aedcfeca2dd410049cf8"
+checksum = "ab512a34b3c2c5e465731cc7668edf79208bbe520be03484eeb05e63ed221735"
 dependencies = [
  "blake2",
  "crc32fast",
@@ -7701,9 +7696,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.4"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8e946cc0cc711189c0b0249fb8b599cbeeab9784d83c415719368bb8d4ac64"
+checksum = "0dec8a8073036902368c2cdc0387e85ff9a37054d7e7c98e592145e0c92cd4fb"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -7716,9 +7711,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.4"
+version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a296c3079b5fefbc499e1de58dc26c09b1b9a5952d26694ee89f04a43ebbb3e"
+checksum = "312270ee71e1cd70289dacf597cab7b207aa107d2f28191c2ae45b2ece18a260"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7740,9 +7735,9 @@ checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
 
 [[package]]
 name = "parking"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
+checksum = "e52c774a4c39359c1d1c52e43f73dd91a75a614652c825408eec30c95a9b2067"
 
 [[package]]
 name = "parking_lot"
@@ -7848,19 +7843,20 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
+checksum = "c022f1e7b65d6a24c0dbbd5fb344c66881bc01f3e5ae74a1c8100f2f985d98a4"
 dependencies = [
+ "memchr",
  "thiserror",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666d00490d4ac815001da55838c500eafb0320019bbaa44444137c48b443a853"
+checksum = "35513f630d46400a977c4cb58f78e1bfbe01434316e60c37d27b9ad6139c66d8"
 dependencies = [
  "pest",
  "pest_generator",
@@ -7868,26 +7864,26 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ca01446f50dbda87c1786af8770d535423fa8a53aec03b8f4e3d7eb10e0929"
+checksum = "bc9fc1b9e7057baba189b5c626e2d6f40681ae5b6eb064dc7c7834101ec8123a"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56af0a30af74d0445c0bf6d9d051c979b516a1a5af790d251daee76005420a48"
+checksum = "1df74e9e7ec4053ceb980e7c0c8bd3594e977fde1af91daba9c928e8e8c6708d"
 dependencies = [
  "once_cell",
  "pest",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -7897,7 +7893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
 ]
 
 [[package]]
@@ -7917,7 +7913,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -7928,9 +7924,9 @@ checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -7944,8 +7940,18 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.8",
+ "spki 0.7.2",
 ]
 
 [[package]]
@@ -7962,9 +7968,9 @@ checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 
 [[package]]
 name = "platforms"
-version = "3.0.2"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
+checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
 
 [[package]]
 name = "polling"
@@ -7978,7 +7984,7 @@ dependencies = [
  "concurrent-queue",
  "libc",
  "log",
- "pin-project-lite 0.2.12",
+ "pin-project-lite 0.2.13",
  "windows-sys 0.48.0",
 ]
 
@@ -8031,7 +8037,7 @@ checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
  "float-cmp",
- "itertools",
+ "itertools 0.10.5",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -8065,9 +8071,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -8128,9 +8134,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -8190,7 +8196,7 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
@@ -8224,7 +8230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -8238,12 +8244,6 @@ checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost",
 ]
-
-[[package]]
-name = "psl-types"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "psm"
@@ -8282,20 +8282,20 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.9.4"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31999cfc7927c4e212e60fd50934ab40e8e8bfd2d493d6095d2d306bc0764d9"
+checksum = "94b0b33c13a79f669c85defaf4c275dc86a0c0372807d0ca3d78e0bb87274863"
 dependencies = [
  "bytes",
  "rand 0.8.5",
- "ring",
+ "ring 0.16.20",
  "rustc-hash",
- "rustls 0.20.8",
+ "rustls 0.20.9",
  "slab",
  "thiserror",
  "tinyvec",
  "tracing",
- "webpki 0.22.0",
+ "webpki 0.22.4",
 ]
 
 [[package]]
@@ -8401,9 +8401,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",
@@ -8411,14 +8411,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -8428,8 +8426,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
- "ring",
- "time 0.3.27",
+ "ring 0.16.20",
+ "time",
  "x509-parser 0.13.2",
  "yasna",
 ]
@@ -8441,8 +8439,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
- "ring",
- "time 0.3.27",
+ "ring 0.16.20",
+ "time",
  "yasna",
 ]
 
@@ -8477,14 +8475,14 @@ dependencies = [
 
 [[package]]
 name = "reed-solomon-novelpoly"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd8f48b2066e9f69ab192797d66da804d1935bf22763204ed3675740cb0f221"
+checksum = "58130877ca403ab42c864fbac74bb319a0746c07a634a92a5cfc7f54af272582"
 dependencies = [
  "derive_more",
  "fs-err",
- "itertools",
- "static_init 0.5.2",
+ "itertools 0.11.0",
+ "static_init",
  "thiserror",
 ]
 
@@ -8505,7 +8503,7 @@ checksum = "7f7473c2cfcf90008193dd0e3e16599455cb601a9fce322b5bb55de799664925"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -8522,14 +8520,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.6",
- "regex-syntax 0.7.4",
+ "regex-automata 0.4.1",
+ "regex-syntax 0.8.0",
 ]
 
 [[package]]
@@ -8543,13 +8541,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.8.0",
 ]
 
 [[package]]
@@ -8560,9 +8558,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "c3cbb081b9784b07cceb8824c8583f86db4814d172ab043f3c23f7dc600bf83d"
 
 [[package]]
 name = "region"
@@ -8606,10 +8604,24 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babe80d5c16becf6594aa32ad2be8fe08498e7ae60b77de8df700e67f191d7e"
+dependencies = [
+ "cc",
+ "getrandom 0.2.10",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8813,7 +8825,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.18",
+ "semver 1.0.20",
 ]
 
 [[package]]
@@ -8841,9 +8853,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
+version = "0.37.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+checksum = "4279d76516df406a8bd37e7dff53fd37d1a093f997a3c34a5c21658c126db06d"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -8855,14 +8867,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "5a74ee2d7c2581cd139b42447d7d9389b889bdaad3a73f1ebb16f2a3237bb19c"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.5",
+ "linux-raw-sys 0.4.10",
  "windows-sys 0.48.0",
 ]
 
@@ -8874,21 +8886,33 @@ checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64 0.13.1",
  "log",
- "ring",
+ "ring 0.16.20",
  "sct 0.6.1",
  "webpki 0.21.4",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
  "log",
- "ring",
+ "ring 0.16.20",
  "sct 0.7.0",
- "webpki 0.22.0",
+ "webpki 0.22.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+dependencies = [
+ "log",
+ "ring 0.16.20",
+ "rustls-webpki",
+ "sct 0.7.0",
 ]
 
 [[package]]
@@ -8909,7 +8933,17 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+dependencies = [
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -9895,7 +9929,7 @@ dependencies = [
  "sp-transaction-storage-proof",
  "sp-trie",
  "sp-version",
- "static_init 1.0.3",
+ "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
  "thiserror",
@@ -10167,8 +10201,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -10177,8 +10211,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -10200,9 +10234,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.6.1",
  "generic-array 0.14.7",
- "pkcs8",
+ "pkcs8 0.9.0",
  "subtle",
  "zeroize",
 ]
@@ -10268,9 +10302,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 dependencies = [
  "serde",
 ]
@@ -10283,29 +10317,29 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.185"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.185"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -10338,9 +10372,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -10374,9 +10408,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -10395,18 +10429,18 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "signal-hook-registry"
@@ -10428,6 +10462,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+
+[[package]]
 name = "simba"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10442,9 +10482,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -10484,9 +10524,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "snap"
@@ -10503,11 +10543,11 @@ dependencies = [
  "aes-gcm 0.9.4",
  "blake2",
  "chacha20poly1305",
- "curve25519-dalek 4.0.0",
+ "curve25519-dalek 4.1.1",
  "rand_core 0.6.4",
- "ring",
+ "ring 0.16.20",
  "rustc_version",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "subtle",
 ]
 
@@ -10523,9 +10563,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -10817,7 +10857,7 @@ dependencies = [
  "blake2",
  "byteorder",
  "digest 0.10.7",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "sha3",
  "sp-std",
  "twox-hash",
@@ -10885,8 +10925,8 @@ version = "7.0.0"
 source = "git+https://github.com/InfraBlockchain/infra-substrate?branch=master#c08c9aeb48966f57907d9fac59ec3b6e31255423"
 dependencies = [
  "bytes",
- "ed25519",
- "ed25519-dalek",
+ "ed25519 1.5.3",
+ "ed25519-dalek 1.0.1",
  "futures",
  "libsecp256k1",
  "log",
@@ -11259,13 +11299,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spki"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der 0.7.8",
 ]
 
 [[package]]
@@ -11297,18 +11353,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "static_init"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11b73400442027c4adedda20a9f9b7945234a5bd8d5f7e86da22bd5d0622369c"
-dependencies = [
- "cfg_aliases",
- "libc",
- "parking_lot 0.11.2",
- "static_init_macro 0.5.0",
-]
-
-[[package]]
-name = "static_init"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a2a1c578e98c1c16fc3b8ec1328f7659a500737d7a0c6d625e73e830ff9c1f6"
@@ -11318,21 +11362,8 @@ dependencies = [
  "libc",
  "parking_lot 0.11.2",
  "parking_lot_core 0.8.6",
- "static_init_macro 1.0.2",
+ "static_init_macro",
  "winapi",
-]
-
-[[package]]
-name = "static_init_macro"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2261c91034a1edc3fc4d1b80e89d82714faede0515c14a75da10cb941546bbf"
-dependencies = [
- "cfg_aliases",
- "memchr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -11387,7 +11418,7 @@ dependencies = [
  "lazy_static",
  "md-5",
  "rand 0.8.5",
- "ring",
+ "ring 0.16.20",
  "subtle",
  "thiserror",
  "tokio",
@@ -11524,9 +11555,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11585,17 +11616,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.0",
+ "fastrand 2.0.1",
  "redox_syscall 0.3.5",
- "rustix 0.38.8",
+ "rustix 0.38.18",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
@@ -11608,22 +11639,22 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -11687,20 +11718,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb39ee79a6d8de55f48f2293a830e040392f1c5f16e336bdd1788cd0aadce07"
+checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
 dependencies = [
  "deranged",
  "itoa",
@@ -11711,15 +11731,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733d258752e9303d392b94b75230d07b0b9c489350c69b851fc6c065fde3e8f9"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]
@@ -11736,7 +11756,7 @@ dependencies = [
  "pbkdf2 0.11.0",
  "rand 0.8.5",
  "rustc-hash",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "thiserror",
  "unicode-normalization",
  "wasm-bindgen",
@@ -11770,9 +11790,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
 dependencies = [
  "backtrace",
  "bytes",
@@ -11780,9 +11800,9 @@ dependencies = [
  "mio",
  "num_cpus",
  "parking_lot 0.12.1",
- "pin-project-lite 0.2.12",
+ "pin-project-lite 0.2.13",
  "signal-hook-registry",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -11795,7 +11815,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -11804,9 +11824,19 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.20.8",
+ "rustls 0.20.9",
  "tokio",
- "webpki 0.22.0",
+ "webpki 0.22.4",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.7",
+ "tokio",
 ]
 
 [[package]]
@@ -11816,22 +11846,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.12",
+ "pin-project-lite 0.2.13",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
- "pin-project-lite 0.2.12",
+ "pin-project-lite 0.2.13",
  "tokio",
  "tracing",
 ]
@@ -11853,11 +11883,11 @@ checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "toml_datetime",
  "winnow",
 ]
@@ -11886,7 +11916,7 @@ dependencies = [
  "http",
  "http-body",
  "http-range-header",
- "pin-project-lite 0.2.12",
+ "pin-project-lite 0.2.13",
  "tower-layer",
  "tower-service",
 ]
@@ -11911,7 +11941,7 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
- "pin-project-lite 0.2.12",
+ "pin-project-lite 0.2.13",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -11924,7 +11954,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -12143,7 +12173,7 @@ dependencies = [
  "log",
  "md-5",
  "rand 0.8.5",
- "ring",
+ "ring 0.16.20",
  "stun",
  "thiserror",
  "tokio",
@@ -12164,9 +12194,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucd-trie"
@@ -12194,9 +12224,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -12209,9 +12239,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"
@@ -12241,9 +12271,9 @@ dependencies = [
 
 [[package]]
 name = "unsigned-varint"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
+checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -12258,10 +12288,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
-name = "url"
-version = "2.4.0"
+name = "untrusted"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna 0.4.0",
@@ -12324,15 +12360,15 @@ dependencies = [
 
 [[package]]
 name = "waker-fn"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -12352,12 +12388,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -12386,7 +12416,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -12420,7 +12450,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -12591,7 +12621,7 @@ dependencies = [
  "log",
  "rustix 0.36.15",
  "serde",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "toml",
  "windows-sys 0.42.0",
  "zstd",
@@ -12735,18 +12765,18 @@ version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
 name = "webpki"
-version = "0.22.0"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.3",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -12755,8 +12785,14 @@ version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
- "webpki 0.22.0",
+ "webpki 0.22.4",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "webrtc"
@@ -12774,17 +12810,17 @@ dependencies = [
  "rand 0.8.5",
  "rcgen 0.9.3",
  "regex",
- "ring",
+ "ring 0.16.20",
  "rtcp",
  "rtp",
  "rustls 0.19.1",
  "sdp",
  "serde",
  "serde_json",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "stun",
  "thiserror",
- "time 0.3.27",
+ "time",
  "tokio",
  "turn",
  "url",
@@ -12821,7 +12857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a00f4242f2db33307347bd5be53263c52a0331c96c14292118c9a6bb48d267"
 dependencies = [
  "aes 0.6.0",
- "aes-gcm 0.10.2",
+ "aes-gcm 0.10.3",
  "async-trait",
  "bincode",
  "block-modes",
@@ -12838,13 +12874,13 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rcgen 0.10.0",
- "ring",
+ "ring 0.16.20",
  "rustls 0.19.1",
  "sec1",
  "serde",
  "sha1",
- "sha2 0.10.7",
- "signature",
+ "sha2 0.10.8",
+ "signature 1.6.4",
  "subtle",
  "thiserror",
  "tokio",
@@ -12968,20 +13004,21 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
  "either",
- "libc",
+ "home",
  "once_cell",
+ "rustix 0.38.18",
 ]
 
 [[package]]
 name = "wide"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa469ffa65ef7e0ba0f164183697b89b854253fd31aeb92358b7b6155177d62f"
+checksum = "ebecebefc38ff1860b4bc47550bbfa63af5746061cf0d29fcd7fa63171602598"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -13011,9 +13048,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -13225,9 +13262,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.14"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
+checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
 dependencies = [
  "memchr",
 ]
@@ -13268,7 +13305,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
 dependencies = [
- "curve25519-dalek 4.0.0",
+ "curve25519-dalek 4.1.1",
  "rand_core 0.6.4",
  "serde",
  "zeroize",
@@ -13287,10 +13324,10 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry 0.4.0",
- "ring",
+ "ring 0.16.20",
  "rusticata-macros",
  "thiserror",
- "time 0.3.27",
+ "time",
 ]
 
 [[package]]
@@ -13308,7 +13345,7 @@ dependencies = [
  "oid-registry 0.6.1",
  "rusticata-macros",
  "thiserror",
- "time 0.3.27",
+ "time",
 ]
 
 [[package]]
@@ -13412,7 +13449,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.27",
+ "time",
 ]
 
 [[package]]
@@ -13432,7 +13469,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7617,6 +7617,8 @@ dependencies = [
  "pallet-authorship",
  "pallet-balances",
  "pallet-collator-selection",
+ "pallet-preimage",
+ "pallet-scheduler",
  "pallet-session",
  "pallet-sudo",
  "pallet-system-token",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ada-url"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ef667a8b52aca2f70b570309cb9fde2d715c9c387e3c80b53df05c87d47ff10"
+dependencies = [
+ "cc",
+ "derive_more",
+ "link_args",
+]
+
+[[package]]
+name = "addr"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93b8a41dbe230ad5087cc721f8d41611de654542180586b315d9f4cf6b72bef"
+dependencies = [
+ "psl-types",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5688,6 +5708,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "link_args"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c7721e472624c9aaad27a5eb6b7c9c6045c7a396f2efb6dabaec1b640d5e89b"
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7359,6 +7385,8 @@ dependencies = [
 name = "pallet-urauth"
 version = "0.1.0"
 dependencies = [
+ "ada-url",
+ "addr",
  "bs58",
  "fixedstr",
  "frame-benchmarking",
@@ -8208,6 +8236,12 @@ checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "psm"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,124 @@
-# Substrate Cumulus Parachain Template
+## UR-Auth
+**_UR-Auth_** 는 _Universal Resource Auth_ 의 약자로 URI(Uniform Resource Identifier)로 표현되는 웹 데이터 및 저작권이 있는 유무형 자산들에 대해 그 소유권을 블록체인 기술과 DID(Decentralized Identifiers) 기술을 이용하여 인터넷 상에 공개적으로 등록할 수 있도록 하는 프로토콜입니다. URI 는 온/오프라인 상의 논리적 물리적 리소스를 고유하게 식별할 수 있는 웹 기술에서 통용되는 식별자(Identifier)로써 블록체인에 해당 URI 의 소유자 DID 를 이용하여 그 소유권을 등록하게 되고 거대 AI 가 이를 학습할 때 정당하게 그 소유권을 주장할 수 있는 기술적인 방법을 마련할 수 있게 됩니다. 
 
-A new [Cumulus](https://github.com/InfraBlockchain/infra-cumulus/)-based Substrate node, ready for hacking ☁️..
+## Data Ownership Register
+
+데이터에 대한 소유권을 _UR-Auth_ 블록체인에 등록하는 타입은 크게 세가지로 나눕니다.
+
+- **도메인**: `https://www.bc-labs.net` 고 같은 일반적인 도메인을 의미합니다.
+- **웹 서비스 계정**: `https://instagram.com/user` 과 같이 어떤 서비스에 대한 계정을 의미합니다.
+- **데이터 파일의 저작권**: 로컬 데이터에 대한 소유권을 의미합니다. 여기서는 ipfs 와 같이 분산형 저장소의 주소값(e.g CID) 이 들어갈 수 있습니다.
+- **데이터셋**: `URAuthTree` 에 등록된 URI 혹은 등록되지 않은 URI 를 이용하여 만든 데이터셋에 대한 소유권을 의미합니다. 해당 데이터셋이 저장되어있는 저장소에 대한 위치값이 들어갈 수 있습니다.
+
+각 영역별 소유권을 등록하는 방법은 다음과 같습니다:
+
+### 도메인
+
+1. 도메인 소유자는 자신의 DID를 생성하고 **_UR-Auth_** 블록체인에 `request_register_ownership` 트랜잭션을 전송합니다.
+
+2. **_UR-Auth_** 블록체인에서 챌린지 값을 생성합니다.
+
+3. 도메인 소유자는 도메인 검증 정보를 담고 있는 _*.json_ 파일을 생성한 후 해당 도메인의 `root` 디렉토리에 업로드합니다. 
+예를 들면, `bc-labs.net/root` 에 `challenge.json` 파일을 업로드합니다.
+
+4. 신뢰할 수 있는 노드로 구성된 오라클 노드들은 해당 _*.json_ 파일을 다운로드 후 **_UR-Auth_** 블록체인에 `verify_challenge` 트랜잭션을 전송합니다. 
+
+5. 정족수 이상의 오라클 노드(e.g 60% 이상)에 의해 검증이 완료되면 해당 도메인은 **_[UR-Auth Tree]()_** 에 등록이 되고 소유권 등록이 완료됩니다.
+
+### 웹 서비스 계정
+
+OAuth 인증을 통하여 계정에 대한 소유권을 인증할 수 있는 경우:
+
+- `claim_ownership` 트랜잭션을 전송하여 해당 URI 를 `UR-Auth Tree` 에 등록합니다.
+
+OAuth 인증이 불가능한 경우:
+
+1. 유저는 자신의 피드에 계정에 대한 소유권을 증명할 수 있는 증명서를 포스팅합니다. 
+
+2. 신뢰할 수 있는 노드로 구성된 오라클 노드들에 의해 위와 같이 검증 절차를 거칩니다.
+
+3. 정족수 이상의 오라클 노드에 의한 검증이 완료되면 `UR-Auth Tree`
+ 에 등록합니다.
+
+### 데이터 파일에 대한 저작권 및 데이터셋
+
+1. 파일 및 데이터셋을 등록하게 되면 `urauth://file/{cid}` 혹은 `urauth://dataset/{cid}` URI 를 발급받게 됩니다.
+
+2. 해당 URI 를 `UR-Auth Tree` 에 등록하게 됩니다.
+
+## UR-Auth Tree
+
+웹사이트 URL 및 웹사이트 내 하위 페이지 URL들은 블록체인 상에서 Tree 데이터 구조의 각 노드들로 표현될 수 있습니다. 하나의 **_UR-Auth Tree_** 는 하나의 웹사이트 도메인과 해당 도메인 내 URI로 식별되는 데이터들에 대응하며, **_UR-Auth Tree_** 의 각 노드는 해당 URI의 소유권자(DID) 정보, 저작권정보, 데이터 접근 규칙 등이 규정된 **_UR-Auth Document_** 를 저장하고 있습니다. 
+
+### UR-Auth Tree 등록 규칙
+
+1. **_UR-Auth Tree_** 의 모든 하위 노드의 등록은 오라클에 의한 검증이 아니라면 그 상위 노드의 소유자 중 한 소유자에 의해 등록되어야 합니다.
+
+2. `http:` 혹은 `https:` 은 같은 것으로 간주되며 생략되어 등록되어야 하며 그 이외의 프로토콜은 명시되어 등록되어야 합니다.
+
+3. `www` 는 생략되어 등록되며 그 이외의 접두사는 명시되어 등록되어야 합니다.
+
+4. 루트 노드는 오라클에 의해 검증된 후 등록되어야 합니다.
+
+## Universal Resource Auth (UR-Auth) Document
+
+**_UR-Auth Tree_** 의 각 노드는 해당 URI와 모든 하위 URI들에 적용되는 소유권 정보, 저작권 정보, 데이터 접근 규칙 등의 정보가 기록된 **_UR-Auth Document_**를 갖습니다. **_UR-Auth Document_** 는 해당 노드의 소유자 DID에 의해서만 내용이 수정될 수 있습니다.
+
+```rust
+#[derive(Encode, Decode, Clone, PartialEq, Debug, Eq, TypeInfo)]
+pub struct URAuthDoc<Account> {
+    pub id: DocId,
+    pub created_at: u128,
+    pub updated_at: u128,
+    pub multi_owner_did: MultiDID<Account>,
+    pub identity_info: Option<Vec<IdentityInfo>>,
+    pub content_metadata: Option<ContentMetadata>,
+    pub copyright_info: Option<CopyrightInfo>,
+    pub access_rules: Option<Vec<AccessRule>>,
+    pub asset: Option<MultiAsset>,
+    pub data_source: Option<URI>,
+    pub proofs: Option<Vec<Proof>>,
+}
+```
+
+### id
+해당 문서의 식별자
+
+### created_at
+해당 문서가 생성된 시간
+
+### updated_at
+해당 문서가 업데이트된 시간
+
+### multi_owner_did
+해당 문서의 소유자 DID 목록
+
+### identity_info
+저작권자의 신원 정보 목록
+
+### contents_metadta
+해당 URI 와 연관된 컨텐츠 메타 데이터 정보
+
+### access_rules
+해당 URI 에 대한 접근 규칙 목록
+
+### asset
+해당 문서가 데이터셋일 경우, 토큰화된 데이터셋에 대한 정보
+
+### data_source
+해당 문서가 데이터셋일 경우, 데이터셋이 저장되어 있는 URI 정보
+
+### proofs
+해당 문서에 대한 전자서명 목록 
+
+## Data Market
+
+**_UR-Auth_** 블록체인 상에 미리 패키징된 웹 Dataset들도 함께 Data Market 에 등록되고 거래 유통되도록 하여, 웹 데이터 수요자들이 웹 데이터 소유자들에게 정당한 데이터 접근 비용을 지불하고 미리 정리된 데이터셋들을 다운로드 받아서 상업용 AI 기계학습 등에 사용하도록 하여 데이터 저작권 문제를 해결할 수 있습니다. 
+
+### Tokenized of Dataset and AI Model
+
+**_URAuth_** 블록체인에는 데이터에 대한 소유권이 명시되어 있기 때문에 해당 URI 로 만들어진 데이터셋 혹은 AI Model 에 대한 지분을 토큰화 할 수 있습니다. 실제로 Data Market 에서 해당 데이터셋이 판매가 되었을 때 토큰화된 지분에 따라 보상을 분배할 수 있습니다. 
+
+## References
+
+- [URAuth White Paper]()

--- a/pallets/urauth/Cargo.toml
+++ b/pallets/urauth/Cargo.toml
@@ -23,6 +23,8 @@ fixedstr = {version = "0.4", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
+addr = { version = "0.15.6", default-features = false }
+ada-url = { version = "2.1.0", default-feautures = false, features = ["libcpp"] }
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, optional = true, branch = "master" }
@@ -53,6 +55,8 @@ std = [
     "fixedstr/std",
     "hex/std",
     "serde",
+    "addr/std",
+    "ada-url/std",
 	"frame-benchmarking/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/pallets/urauth/Cargo.toml
+++ b/pallets/urauth/Cargo.toml
@@ -24,7 +24,7 @@ hex = { version = "0.4.3", default-features = false }
 log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 addr = { version = "0.15.6", default-features = false }
-ada-url = { version = "2.1.0", default-feautures = false, features = ["libcpp"] }
+ada-url = { version = "2.1.0", default-features = false, features = ["libcpp"] }
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, optional = true, branch = "master" }

--- a/pallets/urauth/Cargo.toml
+++ b/pallets/urauth/Cargo.toml
@@ -2,10 +2,10 @@
 name = "pallet-urauth"
 authors = ["blockchain labs"]
 description = "URAuth pallet"
-version = "0.1.0"
+version = "0.1.1"
 license = "Unlicense"
 homepage = "https://bc-labs.net/"
-repository = "https://github.com/InfraBlockchain/infra-substrate/"
+repository = "https://github.com/InfraBlockchain/ur-auth"
 edition = "2021"
 
 [package.metadata.docs.rs]

--- a/pallets/urauth/Cargo.toml
+++ b/pallets/urauth/Cargo.toml
@@ -23,8 +23,6 @@ fixedstr = {version = "0.4", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
-addr = { version = "0.15.6", default-features = false }
-ada-url = { version = "2.1.0", default-features = false, features = ["libcpp"] }
 
 # Substrate
 frame-benchmarking = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, optional = true, branch = "master" }
@@ -55,8 +53,6 @@ std = [
     "fixedstr/std",
     "hex/std",
     "serde",
-    "addr/std",
-    "ada-url/std",
 	"frame-benchmarking/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/pallets/urauth/runtime-api/Cargo.toml
+++ b/pallets/urauth/runtime-api/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 sp-api = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, branch = "master" }
-pallet-urauth = { version = "0.1.0", default-features = false, path = "../" }
+pallet-urauth = { version = "0.1.1", default-features = false, path = "../" }
 
 [features]
 default = ["std"]

--- a/pallets/urauth/src/lib.rs
+++ b/pallets/urauth/src/lib.rs
@@ -129,7 +129,6 @@ pub mod pallet {
     ///
     /// UpdateDocStatus
     #[pallet::storage]
-    #[pallet::unbounded]
     pub type URAuthDocUpdateStatus<T: Config> =
         StorageMap<_, Blake2_128Concat, DocId, UpdateDocStatus<T::AccountId>, ValueQuery>;
 

--- a/pallets/urauth/src/lib.rs
+++ b/pallets/urauth/src/lib.rs
@@ -299,6 +299,8 @@ pub mod pallet {
         NotURAuthDocOwner,
         /// Given URI is not URI which should be verified by Oracle
         NotURIByOracle,
+        /// Given URI is not base URI
+        NotBaseURI,
         /// General error on proof where it is required but it is not given.
         ProofMissing,
         /// Error when challenge value is not stored for requested URI.

--- a/pallets/urauth/src/lib.rs
+++ b/pallets/urauth/src/lib.rs
@@ -23,6 +23,9 @@ pub use pallet::*;
 pub mod types;
 pub use types::*;
 
+pub mod parser;
+pub use parser::*;
+
 #[cfg(test)]
 pub mod mock;
 
@@ -332,6 +335,8 @@ pub mod pallet {
         MaxRequest,
         /// When trying to update different field on `UpdateInProgress` field
         UpdateInProgress,
+        /// Only URL is supported currently. General URI work in progress
+        GeneralURINotSupportedYet
     }
 
     #[pallet::call]

--- a/pallets/urauth/src/lib.rs
+++ b/pallets/urauth/src/lib.rs
@@ -2,6 +2,8 @@
 
 use codec::Encode;
 use fixedstr::zstr;
+use ada_url::Url;
+use addr::parse_domain_name;
 
 use frame_support::{
     pallet_prelude::*,
@@ -273,6 +275,8 @@ pub mod pallet {
         ErrorOnUpdateDoc,
         /// General error on updating `URAuthDocUpdateStatus`(e.g ProofMissing for updating `URAuthDoc`)
         ErrorOnUpdateDocStatus,
+        /// General error on parsing (e.g URI, Challenge Value)
+        ErrorOnParse,
         /// Error on some authorized calls which required origin as Oracle member
         NotOracleMember,
         /// Error when signer of signature is not `URAuthDoc` owner.
@@ -645,7 +649,6 @@ impl<T: Config> Pallet<T> {
         match res {
             VerificationSubmissionResult::Complete => {
                 let (count, urauth_doc) = Self::new_urauth_doc(owner_did, None, None)?;
-                Counter::<T>::put(count);
                 URAuthTree::<T>::insert(&uri, urauth_doc.clone());
                 Self::remove_all_uri_related(uri.clone());
                 Self::deposit_event(Event::<T>::URAuthTreeRegistered {

--- a/pallets/urauth/src/lib.rs
+++ b/pallets/urauth/src/lib.rs
@@ -16,7 +16,7 @@ use sp_runtime::{
     traits::{BlakeTwo256, IdentifyAccount, Verify},
     AccountId32, MultiSignature, MultiSigner,
 };
-use sp_std::{vec::Vec, if_std};
+use sp_std::{if_std, vec::Vec};
 use xcm::latest::MultiAsset;
 
 pub use pallet::*;
@@ -361,7 +361,10 @@ pub mod pallet {
             );
             let maybe_register_uri =
                 Self::check_request_type(uri_request_type.clone(), &claim_type, &uri)?;
-            ensure!(URAuthTree::<T>::get(&maybe_register_uri).is_none(), Error::<T>::AlreadyRegistered);
+            ensure!(
+                URAuthTree::<T>::get(&maybe_register_uri).is_none(),
+                Error::<T>::AlreadyRegistered
+            );
             let bounded_uri: URI = uri
                 .clone()
                 .try_into()
@@ -526,7 +529,10 @@ pub mod pallet {
                 Error::<T>::BadClaim
             );
             let maybe_register_uri = Self::check_request_type(uri_request_type, &claim_type, &uri)?;
-            ensure!(URAuthTree::<T>::get(&maybe_register_uri).is_none(), Error::<T>::AlreadyRegistered);
+            ensure!(
+                URAuthTree::<T>::get(&maybe_register_uri).is_none(),
+                Error::<T>::AlreadyRegistered
+            );
             let bounded_uri: URI = uri.try_into().map_err(|_| Error::<T>::OverMaxSize)?;
             let bounded_owner_did: OwnerDID =
                 owner_did.try_into().map_err(|_| Error::<T>::OverMaxSize)?;
@@ -793,13 +799,20 @@ where
                     }
                 }
             }
-            URIRequestType::Any { is_root, maybe_parent_acc } => {
+            URIRequestType::Any {
+                is_root,
+                maybe_parent_acc,
+            } => {
                 if is_root {
                     ensure!(parsed_uri_part.is_root(&claim_type), Error::<T>::NotRootURI);
                     let (_, root_uri) = parsed_uri_part.full_uri();
                     root_uri
                 } else {
-                    Self::check_parent_owner(raw_uri, &maybe_parent_acc.ok_or(Error::<T>::BadClaim)?, &claim_type)?;
+                    Self::check_parent_owner(
+                        raw_uri,
+                        &maybe_parent_acc.ok_or(Error::<T>::BadClaim)?,
+                        &claim_type,
+                    )?;
                     raw_uri.clone()
                 }
             }

--- a/pallets/urauth/src/lib.rs
+++ b/pallets/urauth/src/lib.rs
@@ -688,7 +688,8 @@ pub mod pallet {
 
 impl<T: Config> Pallet<T> 
 where
-    URIFor<T>: Into<URI>
+    URIFor<T>: Into<URI>,
+    URIPartFor<T>: IsType<URIPart>,
 {
     /// 16 bytes uuid based on `URAuthDocCount`
     fn doc_id() -> Result<DocId, DispatchError> {
@@ -719,7 +720,7 @@ where
                     bounded_uri = T::URAuthParser::is_root(&uri_part)?.into();
                 }
                 if let Some(uris_by_oracle) = URIByOracle::<T>::get(&uri_request_type) {
-                    ensure!(uris_by_oracle.contains(&bounded_uri), Error::<T>::NotValidURI);
+                    ensure!(uris_by_oracle.contains(&uri_part.into()), Error::<T>::NotValidURI);
                 } else {
                     return Err(Error::<T>::BadClaim.into())
                 }

--- a/pallets/urauth/src/lib.rs
+++ b/pallets/urauth/src/lib.rs
@@ -102,7 +102,8 @@ pub mod pallet {
     pub type Metadata<T: Config> = StorageMap<_, Twox128, URI, RequestMetadata>;
 
     #[pallet::storage]
-    pub type RequestedURIs<T: Config> = StorageMap<_, Twox128, BlockNumberFor<T>, BoundedVec<URI, T::MaxRequest>>;
+    pub type RequestedURIs<T: Config> =
+        StorageMap<_, Twox128, BlockNumberFor<T>, BoundedVec<URI, T::MaxRequest>>;
 
     #[pallet::storage]
     pub type DataSet<T: Config> = StorageMap<_, Twox128, URI, DataSetMetadata<AnyText>>;
@@ -193,13 +194,13 @@ pub mod pallet {
     pub type Counter<T: Config> = StorageValue<_, URAuthDocCount, ValueQuery>;
 
     #[pallet::hooks]
-    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> 
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T>
     where
         URIFor<T>: Into<URI>,
         URIPartFor<T>: IsType<URIPart>,
     {
         fn on_initialize(n: BlockNumberFor<T>) -> Weight {
-            let (r,w) = Self::handle_expired_requsted_uris(&n);
+            let (r, w) = Self::handle_expired_requsted_uris(&n);
             T::DbWeight::get().reads_writes(r, w)
         }
     }
@@ -335,7 +336,7 @@ pub mod pallet {
         /// When trying to add oracle member more than `T::MaxOracleMembers`
         MaxOracleMembers,
         /// Max number of request of URI per block has been reached.
-        MaxRequest, 
+        MaxRequest,
         /// When trying to update different field on `UpdateInProgress` field
         UpdateInProgress,
     }
@@ -769,7 +770,8 @@ where
         let expire = <frame_system::Pallet<T>>::block_number() + T::VerificationPeriod::get();
         RequestedURIs::<T>::try_mutate_exists(expire, |uris| -> DispatchResult {
             let mut new = uris.clone().map_or(Default::default(), |v| v);
-            new.try_push(uri.clone()).map_err(|_| Error::<T>::MaxRequest)?;
+            new.try_push(uri.clone())
+                .map_err(|_| Error::<T>::MaxRequest)?;
             *uris = Some(new);
             Ok(())
         })?;
@@ -942,8 +944,8 @@ where
                 w += 3;
             }
         }
-        RequestedURIs::<T>::remove(n); 
-        (r, w+1)
+        RequestedURIs::<T>::remove(n);
+        (r, w + 1)
     }
 
     /// Handle the result of _challenge value_ verification based on `VerificationSubmissionResult`

--- a/pallets/urauth/src/lib.rs
+++ b/pallets/urauth/src/lib.rs
@@ -357,8 +357,12 @@ pub mod pallet {
                 matches!(uri_request_type, URIRequestType::Oracle { .. }),
                 Error::<T>::BadClaim
             );
-            let maybe_register_uri = Self::check_request_type(uri_request_type.clone(), &claim_type, &uri)?;
-            let bounded_uri: URI = uri.clone().try_into().map_err(|_| Error::<T>::OverMaxSize)?;
+            let maybe_register_uri =
+                Self::check_request_type(uri_request_type.clone(), &claim_type, &uri)?;
+            let bounded_uri: URI = uri
+                .clone()
+                .try_into()
+                .map_err(|_| Error::<T>::OverMaxSize)?;
             let bounded_owner_did: OwnerDID =
                 owner_did.try_into().map_err(|_| Error::<T>::OverMaxSize)?;
             Self::verify_request_proof(&bounded_uri, &bounded_owner_did, &proof, signer)?;
@@ -370,7 +374,7 @@ pub mod pallet {
             ChallengeValue::<T>::insert(&bounded_uri, cv);
             Metadata::<T>::insert(
                 &bounded_uri,
-                RequestMetadata::new(bounded_owner_did, cv, claim_type, maybe_register_uri)
+                RequestMetadata::new(bounded_owner_did, cv, claim_type, maybe_register_uri),
             );
 
             Self::deposit_event(Event::<T>::URAuthRegisterRequested { uri: bounded_uri });
@@ -875,7 +879,7 @@ where
         verification_submission: VerificationSubmission<T>,
         uri: &URI,
         owner_did: T::AccountId,
-        metadata: RequestMetadata
+        metadata: RequestMetadata,
     ) -> Result<(), DispatchError> {
         match res {
             VerificationSubmissionResult::Complete => {

--- a/pallets/urauth/src/lib.rs
+++ b/pallets/urauth/src/lib.rs
@@ -277,6 +277,8 @@ pub mod pallet {
         BadRequest,
         /// General error on claiming ownership
         BadClaim,
+        /// General error on URI
+        BadURI,
         /// Size is over limit of `MAX_*`
         OverMaxSize,
         /// Error on converting raw-json to json-string.
@@ -361,10 +363,6 @@ pub mod pallet {
             proof: MultiSignature,
         ) -> DispatchResult {
             let _ = ensure_signed(origin)?;
-            ensure!(
-                T::URAuthParser::is_valid_claim(&uri, claim_type.clone().into()).is_ok(), 
-                Error::<T>::BadRequest
-            );
             let bounded_uri: URI = uri.try_into().map_err(|_| Error::<T>::OverMaxSize)?;
             let bounded_owner_did: OwnerDID =
                 owner_did.try_into().map_err(|_| Error::<T>::OverMaxSize)?;
@@ -520,7 +518,7 @@ pub mod pallet {
             let bounded_owner_did: OwnerDID =
                 owner_did.try_into().map_err(|_| Error::<T>::OverMaxSize)?;
             let signer_acc = Self::verify_request_proof(&bounded_uri, &bounded_owner_did, &proof, signer)?;
-            T::URAuthParser::check_parent_owner(&uri, signer_acc)?;
+            T::URAuthParser::check_parent_owner(&uri, &signer_acc, &claim_type)?;
             let owner =
                 Self::account_id_from_source(AccountIdSource::DID(bounded_owner_did.to_vec()))?;
             // ToDo: Check that raw_url is not base

--- a/pallets/urauth/src/lib.rs
+++ b/pallets/urauth/src/lib.rs
@@ -340,7 +340,7 @@ pub mod pallet {
         URIFor<T>: Into<URI>,
         URIPartFor<T>: IsType<URIPart>,
         ClaimTypeFor<T>: From<ClaimType>,
-        ChallengeValueFor<T>: Into<URAuthChallengeValue>
+        ChallengeValueFor<T>: Into<URAuthChallengeValue>,
     {
         // Description:
         // This transaction is for a domain owner to request ownership registration in the URAuthTree.

--- a/pallets/urauth/src/mock.rs
+++ b/pallets/urauth/src/mock.rs
@@ -76,6 +76,7 @@ parameter_types! {
 impl pallet_urauth::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type UnixTime = Timestamp;
+    type URAuthParser = URAuthParser;
     type MaxOracleMembers = MaxOracleMembers;
     type MaxURIByOracle = ConstU32<100>;
     type AuthorizedOrigin = EnsureRoot<MockAccountId>;

--- a/pallets/urauth/src/mock.rs
+++ b/pallets/urauth/src/mock.rs
@@ -194,7 +194,6 @@ pub enum ProofType<Account: Encode> {
 pub struct MockProver<Account>(PhantomData<Account>);
 
 impl<Account: Encode> MockProver<Account> {
-
     pub fn new() -> Self {
         Self(Default::default())
     }
@@ -412,29 +411,25 @@ impl RequestCall {
 
     pub fn runtime_call(self) -> DispatchResult {
         match self.challenge {
-            Some(_) => {
-                URAuth::request_register_ownership(
-                    self.origin,
-                    self.claim_type,
-                    self.uri,
-                    self.request_type,
-                    self.owner_did,
-                    self.challenge,
-                    self.signer,
-                    self.sig,
-                )
-            },
-            None => {
-                URAuth::claim_ownership(
-                    self.origin, 
-                    self.claim_type, 
-                    self.uri, 
-                    self.request_type, 
-                    self.owner_did, 
-                    self.signer, 
-                    self.sig
-                )
-            }
+            Some(_) => URAuth::request_register_ownership(
+                self.origin,
+                self.claim_type,
+                self.uri,
+                self.request_type,
+                self.owner_did,
+                self.challenge,
+                self.signer,
+                self.sig,
+            ),
+            None => URAuth::claim_ownership(
+                self.origin,
+                self.claim_type,
+                self.uri,
+                self.request_type,
+                self.owner_did,
+                self.signer,
+                self.sig,
+            ),
         }
     }
     pub fn set_origin(mut self, origin: RuntimeOrigin) {
@@ -473,13 +468,16 @@ pub struct AddURIByOracleCall {
     pub origin: RuntimeOrigin,
     pub claim_type: ClaimType,
     pub request_type: URIRequestType<AccountId32>,
-    pub uri: Vec<u8>
+    pub uri: Vec<u8>,
 }
 
 impl AddURIByOracleCall {
     pub fn runtime_call(&self) -> DispatchResult {
         URAuth::add_uri_by_oracle(
-            self.origin.clone(), self.claim_type.clone(), self.request_type.clone(), self.uri.clone()
+            self.origin.clone(),
+            self.claim_type.clone(),
+            self.request_type.clone(),
+            self.uri.clone(),
         )
     }
     pub fn set_claim_type(mut self, claim_type: ClaimType) -> Self {

--- a/pallets/urauth/src/mock.rs
+++ b/pallets/urauth/src/mock.rs
@@ -77,6 +77,7 @@ impl pallet_urauth::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type UnixTime = Timestamp;
     type MaxOracleMembers = MaxOracleMembers;
+    type MaxURIByOracle = ConstU32<100>;
     type AuthorizedOrigin = EnsureRoot<MockAccountId>;
 }
 

--- a/pallets/urauth/src/mock.rs
+++ b/pallets/urauth/src/mock.rs
@@ -234,7 +234,7 @@ impl<Account: Encode> MockProver<Account> {
                     asset,
                     data_source,
                     owner_did,
-                    nonce
+                    nonce,
                 )
                     .encode()
             }

--- a/pallets/urauth/src/mock.rs
+++ b/pallets/urauth/src/mock.rs
@@ -379,9 +379,8 @@ impl MockURAuthDocManager {
 #[derive(Clone)]
 pub struct RequestCall {
     origin: RuntimeOrigin,
-    claim_type: ClaimType,
+    uri_type: URIType,
     uri: Vec<u8>,
-    request_type: URIRequestType<AccountId32>,
     owner_did: Vec<u8>,
     challenge: Option<Randomness>,
     signer: MultiSigner,
@@ -391,9 +390,8 @@ pub struct RequestCall {
 impl RequestCall {
     pub fn new(
         origin: RuntimeOrigin,
-        claim_type: ClaimType,
+        uri_type: URIType,
         uri: Vec<u8>,
-        request_type: URIRequestType<AccountId32>,
         owner_did: Vec<u8>,
         challenge: Option<Randomness>,
         signer: MultiSigner,
@@ -401,9 +399,8 @@ impl RequestCall {
     ) -> Self {
         Self {
             origin,
-            claim_type,
+            uri_type,
             uri,
-            request_type,
             owner_did,
             challenge,
             signer,
@@ -415,9 +412,8 @@ impl RequestCall {
         match self.challenge {
             Some(_) => URAuth::request_register_ownership(
                 self.origin,
-                self.claim_type,
+                self.uri_type,
                 self.uri,
-                self.request_type,
                 self.owner_did,
                 self.challenge,
                 self.signer,
@@ -425,9 +421,8 @@ impl RequestCall {
             ),
             None => URAuth::claim_ownership(
                 self.origin,
-                self.claim_type,
+                self.uri_type,
                 self.uri,
-                self.request_type,
                 self.owner_did,
                 self.signer,
                 self.sig,
@@ -438,16 +433,12 @@ impl RequestCall {
         self.origin = origin;
         self
     }
-    pub fn set_claim_type(mut self, claim_type: ClaimType) -> Self {
-        self.claim_type = claim_type;
+    pub fn set_uri_type(mut self, uri_type: URIType) -> Self {
+        self.uri_type = uri_type;
         self
     }
     pub fn set_uri(mut self, uri: Vec<u8>) -> Self {
         self.uri = uri;
-        self
-    }
-    pub fn set_request_type(mut self, request_type: URIRequestType<AccountId32>) -> Self {
-        self.request_type = request_type;
         self
     }
     pub fn set_owner_did(mut self, owner_did: Vec<u8>) -> Self {
@@ -470,8 +461,7 @@ impl RequestCall {
 
 pub struct AddURIByOracleCall {
     pub origin: RuntimeOrigin,
-    pub claim_type: ClaimType,
-    pub request_type: URIRequestType<AccountId32>,
+    pub uri_type: URIType,
     pub uri: Vec<u8>,
 }
 
@@ -479,17 +469,12 @@ impl AddURIByOracleCall {
     pub fn runtime_call(&self) -> DispatchResult {
         URAuth::add_uri_by_oracle(
             self.origin.clone(),
-            self.claim_type.clone(),
-            self.request_type.clone(),
+            self.uri_type.clone(),
             self.uri.clone(),
         )
     }
-    pub fn set_claim_type(mut self, claim_type: ClaimType) -> Self {
-        self.claim_type = claim_type;
-        self
-    }
-    pub fn set_request_type(mut self, request_type: URIRequestType<AccountId32>) -> Self {
-        self.request_type = request_type;
+    pub fn set_uri_type(mut self, uri_type: URIType) -> Self {
+        self.uri_type = uri_type;
         self
     }
     pub fn set_uri(mut self, uri: Vec<u8>) -> Self {

--- a/pallets/urauth/src/mock.rs
+++ b/pallets/urauth/src/mock.rs
@@ -112,7 +112,7 @@ impl<Account: Encode> MockURAuthHelper<Account> {
         let account_id = account_id.map_or(String::from(ALICE_SS58), |id| id);
         Self {
             mock_doc_manager: MockURAuthDocManager::new(
-                uri.map_or(String::from("www.website1.com"), |uri| uri),
+                uri.map_or(String::from("https://www.website1.com"), |uri| uri),
                 format!("{}{}", "did:infra:ua:", account_id),
                 challenge_value.map_or(String::from("E40Bzg8kAvOIjswwxc29WaQCHuOKwoZC"), |cv| cv),
                 timestamp.map_or(String::from("2023-07-28T10:17:21Z"), |t| t),

--- a/pallets/urauth/src/mock.rs
+++ b/pallets/urauth/src/mock.rs
@@ -432,11 +432,13 @@ impl RequestCall {
             ),
         }
     }
-    pub fn set_origin(mut self, origin: RuntimeOrigin) {
+    pub fn set_origin(mut self, origin: RuntimeOrigin) -> Self {
         self.origin = origin;
+        self
     }
-    pub fn set_claim_type(mut self, claim_type: ClaimType) {
+    pub fn set_claim_type(mut self, claim_type: ClaimType) -> Self {
         self.claim_type = claim_type;
+        self
     }
     pub fn set_uri(mut self, uri: Vec<u8>) -> Self {
         self.uri = uri;

--- a/pallets/urauth/src/mock.rs
+++ b/pallets/urauth/src/mock.rs
@@ -1,5 +1,5 @@
 pub use crate::{self as pallet_urauth, *};
-use frame_support::{parameter_types, traits::Everything};
+use frame_support::{parameter_types, traits::{Everything, EitherOfDiverse}};
 use frame_system::EnsureRoot;
 use sp_core::{sr25519::Signature, H256};
 use sp_runtime::{

--- a/pallets/urauth/src/mock.rs
+++ b/pallets/urauth/src/mock.rs
@@ -1,5 +1,5 @@
 pub use crate::{self as pallet_urauth, *};
-use frame_support::{parameter_types, traits::{Everything, EitherOfDiverse}};
+use frame_support::{parameter_types, traits::Everything};
 use frame_system::EnsureRoot;
 use sp_core::{sr25519::Signature, H256};
 use sp_runtime::{
@@ -367,6 +367,68 @@ impl MockURAuthDocManager {
         let json_output = std::str::from_utf8(&json).unwrap();
 
         json_output.to_string()
+    }
+}
+
+#[derive(Clone)]
+pub struct RequestCall {
+    origin: RuntimeOrigin, 
+    claim_type: ClaimType, 
+    uri: Vec<u8>, 
+    request_type: URIRequestType<AccountId32>, 
+    owner_did: Vec<u8>, 
+    challenge: Option<Randomness>, 
+    signer: MultiSigner, 
+    sig: MultiSignature 
+}
+
+impl RequestCall {
+
+    pub fn new(origin: RuntimeOrigin, claim_type: ClaimType, uri: Vec<u8>, request_type: URIRequestType<AccountId32>, owner_did: Vec<u8>, challenge: Option<Randomness>, signer: MultiSigner, sig: MultiSignature) -> Self {
+        Self {
+            origin,
+            claim_type,
+            uri,
+            request_type,
+            owner_did,
+            challenge,
+            signer,
+            sig 
+        }
+    }
+
+    pub fn runtime_call(self) -> DispatchResult {
+        URAuth::request_register_ownership(self.origin, self.claim_type, self.uri, self.request_type, self.owner_did, self.challenge, self.signer, self.sig)
+    }
+    pub fn set_origin(mut self, origin: RuntimeOrigin) {
+        self.origin = origin;
+    }
+    pub fn set_claim_type(mut self, claim_type: ClaimType) {
+        self.claim_type = claim_type;
+    }
+    pub fn set_uri(mut self, uri: Vec<u8>) -> Self {
+        self.uri = uri;
+        self
+    }
+    pub fn set_request_type(mut self, request_type: URIRequestType<AccountId32>) -> Self {
+        self.request_type = request_type;
+        self
+    }
+    pub fn set_owner_did(mut self, owner_did: Vec<u8>) -> Self {
+        self.owner_did = owner_did;
+        self
+    }
+    pub fn set_challenge(mut self, challenge: Option<Randomness>) -> Self {
+        self.challenge = challenge;
+        self
+    }
+    pub fn set_signer(mut self, signer: MultiSigner) -> Self {
+        self.signer = signer;
+        self 
+    }
+    pub fn set_sig(mut self, sig: MultiSignature) -> Self {
+        self.sig = sig;
+        self
     }
 }
 

--- a/pallets/urauth/src/mock.rs
+++ b/pallets/urauth/src/mock.rs
@@ -372,19 +372,27 @@ impl MockURAuthDocManager {
 
 #[derive(Clone)]
 pub struct RequestCall {
-    origin: RuntimeOrigin, 
-    claim_type: ClaimType, 
-    uri: Vec<u8>, 
-    request_type: URIRequestType<AccountId32>, 
-    owner_did: Vec<u8>, 
-    challenge: Option<Randomness>, 
-    signer: MultiSigner, 
-    sig: MultiSignature 
+    origin: RuntimeOrigin,
+    claim_type: ClaimType,
+    uri: Vec<u8>,
+    request_type: URIRequestType<AccountId32>,
+    owner_did: Vec<u8>,
+    challenge: Option<Randomness>,
+    signer: MultiSigner,
+    sig: MultiSignature,
 }
 
 impl RequestCall {
-
-    pub fn new(origin: RuntimeOrigin, claim_type: ClaimType, uri: Vec<u8>, request_type: URIRequestType<AccountId32>, owner_did: Vec<u8>, challenge: Option<Randomness>, signer: MultiSigner, sig: MultiSignature) -> Self {
+    pub fn new(
+        origin: RuntimeOrigin,
+        claim_type: ClaimType,
+        uri: Vec<u8>,
+        request_type: URIRequestType<AccountId32>,
+        owner_did: Vec<u8>,
+        challenge: Option<Randomness>,
+        signer: MultiSigner,
+        sig: MultiSignature,
+    ) -> Self {
         Self {
             origin,
             claim_type,
@@ -393,12 +401,21 @@ impl RequestCall {
             owner_did,
             challenge,
             signer,
-            sig 
+            sig,
         }
     }
 
     pub fn runtime_call(self) -> DispatchResult {
-        URAuth::request_register_ownership(self.origin, self.claim_type, self.uri, self.request_type, self.owner_did, self.challenge, self.signer, self.sig)
+        URAuth::request_register_ownership(
+            self.origin,
+            self.claim_type,
+            self.uri,
+            self.request_type,
+            self.owner_did,
+            self.challenge,
+            self.signer,
+            self.sig,
+        )
     }
     pub fn set_origin(mut self, origin: RuntimeOrigin) {
         self.origin = origin;
@@ -424,7 +441,7 @@ impl RequestCall {
     }
     pub fn set_signer(mut self, signer: MultiSigner) -> Self {
         self.signer = signer;
-        self 
+        self
     }
     pub fn set_sig(mut self, sig: MultiSignature) -> Self {
         self.sig = sig;

--- a/pallets/urauth/src/mock.rs
+++ b/pallets/urauth/src/mock.rs
@@ -379,7 +379,7 @@ impl MockURAuthDocManager {
 #[derive(Clone)]
 pub struct RequestCall {
     origin: RuntimeOrigin,
-    uri_type: URIType,
+    claim_type: ClaimType,
     uri: Vec<u8>,
     owner_did: Vec<u8>,
     challenge: Option<Randomness>,
@@ -390,7 +390,7 @@ pub struct RequestCall {
 impl RequestCall {
     pub fn new(
         origin: RuntimeOrigin,
-        uri_type: URIType,
+        claim_type: ClaimType,
         uri: Vec<u8>,
         owner_did: Vec<u8>,
         challenge: Option<Randomness>,
@@ -399,7 +399,7 @@ impl RequestCall {
     ) -> Self {
         Self {
             origin,
-            uri_type,
+            claim_type,
             uri,
             owner_did,
             challenge,
@@ -412,7 +412,7 @@ impl RequestCall {
         match self.challenge {
             Some(_) => URAuth::request_register_ownership(
                 self.origin,
-                self.uri_type,
+                self.claim_type,
                 self.uri,
                 self.owner_did,
                 self.challenge,
@@ -421,7 +421,7 @@ impl RequestCall {
             ),
             None => URAuth::claim_ownership(
                 self.origin,
-                self.uri_type,
+                self.claim_type,
                 self.uri,
                 self.owner_did,
                 self.signer,
@@ -433,8 +433,8 @@ impl RequestCall {
         self.origin = origin;
         self
     }
-    pub fn set_uri_type(mut self, uri_type: URIType) -> Self {
-        self.uri_type = uri_type;
+    pub fn set_claim_type(mut self, claim_type: ClaimType) -> Self {
+        self.claim_type = claim_type;
         self
     }
     pub fn set_uri(mut self, uri: Vec<u8>) -> Self {
@@ -461,7 +461,7 @@ impl RequestCall {
 
 pub struct AddURIByOracleCall {
     pub origin: RuntimeOrigin,
-    pub uri_type: URIType,
+    pub claim_type: ClaimType,
     pub uri: Vec<u8>,
 }
 
@@ -469,12 +469,12 @@ impl AddURIByOracleCall {
     pub fn runtime_call(&self) -> DispatchResult {
         URAuth::add_uri_by_oracle(
             self.origin.clone(),
-            self.uri_type.clone(),
+            self.claim_type.clone(),
             self.uri.clone(),
         )
     }
-    pub fn set_uri_type(mut self, uri_type: URIType) -> Self {
-        self.uri_type = uri_type;
+    pub fn set_claim_type(mut self, claim_type: ClaimType) -> Self {
+        self.claim_type = claim_type;
         self
     }
     pub fn set_uri(mut self, uri: Vec<u8>) -> Self {

--- a/pallets/urauth/src/mock.rs
+++ b/pallets/urauth/src/mock.rs
@@ -80,7 +80,7 @@ impl pallet_urauth::Config for Test {
     type MaxOracleMembers = MaxOracleMembers;
     type MaxURIByOracle = ConstU32<100>;
     type VerificationPeriod = ConstU64<3>;
-    type MaxRequest = ConstU32<100>;
+    type MaxRequest = ConstU32<5>;
     type AuthorizedOrigin = EnsureRoot<MockAccountId>;
 }
 
@@ -188,9 +188,9 @@ impl<Account: Encode> MockURAuthHelper<Account> {
 
 #[derive(Clone)]
 pub enum ProofType<Account: Encode> {
-    Request(URI, OwnerDID),
+    Request(URI, OwnerDID, MockBlockNumber),
     Challenge(URI, OwnerDID, Vec<u8>, Vec<u8>),
-    Update(URI, URAuthDoc<Account>, OwnerDID),
+    Update(URI, URAuthDoc<Account>, OwnerDID, MockBlockNumber),
 }
 
 pub struct MockProver<Account>(PhantomData<Account>);
@@ -202,11 +202,11 @@ impl<Account: Encode> MockProver<Account> {
 
     fn raw_payload(&self, proof_type: ProofType<Account>) -> Vec<u8> {
         let raw = match proof_type {
-            ProofType::Request(uri, owner_did) => (uri, owner_did).encode(),
+            ProofType::Request(uri, owner_did, nonce) => (uri, owner_did, nonce).encode(),
             ProofType::Challenge(uri, owner_did, challenge, timestamp) => {
                 (uri, owner_did, challenge, timestamp).encode()
             }
-            ProofType::Update(uri, urauth_doc, owner_did) => {
+            ProofType::Update(uri, urauth_doc, owner_did, nonce) => {
                 let URAuthDoc {
                     id,
                     created_at,
@@ -234,6 +234,7 @@ impl<Account: Encode> MockProver<Account> {
                     asset,
                     data_source,
                     owner_did,
+                    nonce
                 )
                     .encode()
             }

--- a/pallets/urauth/src/mock.rs
+++ b/pallets/urauth/src/mock.rs
@@ -79,6 +79,8 @@ impl pallet_urauth::Config for Test {
     type URAuthParser = URAuthParser<Self>;
     type MaxOracleMembers = MaxOracleMembers;
     type MaxURIByOracle = ConstU32<100>;
+    type VerificationPeriod = ConstU64<3>;
+    type MaxRequest = ConstU32<100>;
     type AuthorizedOrigin = EnsureRoot<MockAccountId>;
 }
 
@@ -509,6 +511,15 @@ impl ExtBuilder {
     pub fn build_and_execute(self, test: impl FnOnce() -> ()) {
         let mut ext = self.build();
         ext.execute_with(test);
+    }
+}
+
+pub fn run_to_block(n: BlockNumberFor<Test>) {
+    while System::block_number() < n {
+        System::on_finalize(System::block_number());
+        System::set_block_number(System::block_number() + 1);
+        System::on_initialize(System::block_number());
+        <URAuth as Hooks<BlockNumberFor<Test>>>::on_initialize(System::block_number());
     }
 }
 

--- a/pallets/urauth/src/mock.rs
+++ b/pallets/urauth/src/mock.rs
@@ -76,7 +76,7 @@ parameter_types! {
 impl pallet_urauth::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type UnixTime = Timestamp;
-    type URAuthParser = URAuthParser;
+    type URAuthParser = URAuthParser<Self>;
     type MaxOracleMembers = MaxOracleMembers;
     type MaxURIByOracle = ConstU32<100>;
     type AuthorizedOrigin = EnsureRoot<MockAccountId>;

--- a/pallets/urauth/src/parser.rs
+++ b/pallets/urauth/src/parser.rs
@@ -1,0 +1,610 @@
+
+#![forbid(unsafe_code)]
+#![cfg_attr(feature = "unstable", feature(error_in_core))]
+
+use core::fmt;
+
+use crate::{URIPart, ClaimType, *};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ParseError {
+    InvalidConnect,
+    EmptyInput,
+    Whitespace,
+    NoHost,
+    Invalid,
+}
+
+impl fmt::Display for ParseError {
+    #[cfg(not(tarpaulin_include))]
+    #[cfg_attr(feature = "_nopanic", no_panic::no_panic)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseError::InvalidConnect => {
+                write!(f, "CONNECT requests can only contain \"hostname:port\"")
+            }
+            ParseError::EmptyInput => write!(f, "Empty input"),
+            ParseError::Whitespace => write!(f, "Whitespace"),
+            ParseError::NoHost => {
+                write!(f, "host must be present if there is a schema")
+            }
+            ParseError::Invalid => write!(f, "Invalid URL"),
+        }
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl core::error::Error for ParseError {}
+
+#[derive(Debug, PartialEq, Eq)]
+enum State {
+    SchemeSlash,
+    SchemeSlashSlash,
+    ServerStart,
+    QueryStringStart,
+    FragmentStart,
+    Scheme,
+    ServerWithAt,
+    Server,
+    Path,
+    QueryString,
+    Fragment,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum UrlFields {
+    Scheme,
+    Host,
+    Path,
+    Query,
+    Fragment,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+/// A parsed URL
+pub struct Url<'a> {
+    pub scheme: Option<&'a str>,
+    pub host: Option<&'a str>,
+    pub port: Option<&'a str>,
+    pub path: Option<&'a str>,
+    pub query: Option<&'a str>,
+    pub fragment: Option<&'a str>,
+    pub userinfo: Option<&'a str>,
+}
+
+impl<'a> Url<'a> {
+    #[cfg_attr(feature = "_nopanic", no_panic::no_panic)]
+    /// Parse a URL from a string
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use url_lite::Url;
+    /// # use url_lite::ParseError;
+    ///
+    /// # fn run() -> Result<(), ParseError> {
+    /// let url = Url::parse("http://example.com").expect("Invalid URL");
+    /// # Ok(())
+    /// # }
+    /// # run().unwrap();
+    /// ```
+    pub fn parse(buf: &'a str) -> Result<Url<'a>, ParseError> {
+        parse_url(buf, false)
+    }
+
+    /// Parse as a HTTP CONNECT method URL
+    ///
+    /// Will return an error if the URL contains anything other than hostname
+    /// and port
+    pub fn parse_connect(buf: &'a str) -> Result<Url<'a>, ParseError> {
+        parse_url(buf, true)
+    }
+}
+
+impl<'a> Url<'a> {
+
+    pub fn convert(&self, claim_type: &ClaimType) -> Result<URIPart, ParseError> {
+        let mut sub_domain: Option<Vec<u8>> = None;
+
+        let default_scheme: Vec<u8> = "https".as_bytes().to_vec();
+        let scheme = self.scheme.map_or(default_scheme, |s| {
+            s.as_bytes().to_vec()
+        });
+
+        let path = self.path.map_or(None, |p| {
+            if p.len() == 1 {
+                None 
+            } else {
+                Some(p.as_bytes().to_vec())
+            }
+        });
+
+        let full_host = self.host.map_or("", |h| h);
+        if full_host.is_empty() {
+            return Err(ParseError::NoHost)
+        }
+        let sub_domain_index = self.sub_domain_start_index(full_host, claim_type);
+
+        let host = if let Some(i) = sub_domain_index {
+            sub_domain = Some(full_host[0..=i].as_bytes().to_vec());
+            Some(full_host[i + 1..].as_bytes().to_vec())
+        } else {
+            if *claim_type == ClaimType::Domain {
+                sub_domain = Some("www.".as_bytes().to_vec());
+            }
+            Some(full_host.as_bytes().to_vec())
+        };
+
+        Ok(URIPart::new(scheme, sub_domain, host, path))
+    }
+
+    /// Find the start index of where sub-domain is started.
+    /// ### Example
+    /// 1. file -> None
+    /// 2. website.com -> None
+    /// 3. sub1.website.com -> 4
+    fn sub_domain_start_index(&self, host: &str, claim_type: &ClaimType) -> Option<usize> {
+        let mut count = 0;
+        let mut temp = host.clone();
+        let mut maybe_index: Option<usize> = None;
+        while let Some(i) = temp.rfind('.') {
+            count += 1;
+            if matches!(claim_type, ClaimType::Contents { .. }) {
+                maybe_index = Some(i);
+                break;
+            }
+            if count == 2 {
+                maybe_index = Some(i);
+                break;
+            }
+            temp = &temp[0..i];
+        }
+        maybe_index
+    }
+}
+
+#[cfg_attr(feature = "_nopanic", no_panic::no_panic)]
+fn parse_url(buf: &str, is_connect: bool) -> Result<Url, ParseError> {
+    if buf.is_empty() {
+        return Err(ParseError::EmptyInput);
+    }
+
+    let mut url = Url {
+        scheme: None,
+        host: None,
+        port: None,
+        path: None,
+        query: None,
+        fragment: None,
+        userinfo: None,
+    };
+
+    let mut state = State::ServerStart;
+    let mut old_uf: Option<UrlFields> = None;
+    let mut found_at = false;
+
+    let mut len = 0;
+    let mut off = 0;
+
+    for (i, p) in buf.chars().enumerate() {
+        let uf: UrlFields;
+
+        if p.is_whitespace() {
+            return Err(ParseError::Whitespace);
+        }
+
+        if i == 0 && !is_connect {
+            state = parse_url_start(p)?;
+        } else {
+            state = parse_url_char(state, p)?;
+        }
+
+        // Figure out the next field that we're operating on
+        match state {
+            // Skip delimeters
+            State::SchemeSlash
+            | State::SchemeSlashSlash
+            | State::ServerStart
+            | State::QueryStringStart
+            | State::FragmentStart => {
+                continue;
+            }
+            State::Scheme => {
+                uf = UrlFields::Scheme;
+            }
+            State::ServerWithAt => {
+                found_at = true;
+                uf = UrlFields::Host;
+            }
+            State::Server => {
+                uf = UrlFields::Host;
+            }
+            State::Path => {
+                uf = UrlFields::Path;
+            }
+            State::QueryString => {
+                uf = UrlFields::Query;
+            }
+            State::Fragment => {
+                uf = UrlFields::Fragment;
+            }
+        }
+
+        off += 1;
+        len += 1;
+
+        // Nothing's changed; soldier on
+        if old_uf.as_ref() == Some(&uf) {
+            continue;
+        }
+
+        if let Some(old_uf) = old_uf {
+            let value =
+                Some(buf.get(off - len..off).ok_or(ParseError::Invalid)?);
+            set_url_field(&old_uf, &mut url, value)
+        }
+        old_uf = Some(uf);
+        len = 0;
+        off = i;
+    }
+
+    if let Some(old_uf) = old_uf {
+        let value =
+            Some(buf.get(off - len..off + 1).ok_or(ParseError::Invalid)?);
+        set_url_field(&old_uf, &mut url, value)
+    }
+
+    // host must be present if there is a schema
+    // parsing http:///toto will fail
+    if url.scheme.is_some() && url.host.is_none() {
+        return Err(ParseError::NoHost);
+    }
+
+    if let Some(host_buf) = url.host.take() {
+        url.host = None;
+
+        let mut host_state = if found_at {
+            HttpHostState::UserinfoStart
+        } else {
+            HttpHostState::HostStart
+        };
+
+        let mut off = 0;
+        let mut len = 0;
+
+        for (i, p) in host_buf.chars().enumerate() {
+            let new_host_state = parse_host_char(&host_state, p)?;
+
+            match new_host_state {
+                HttpHostState::Host => {
+                    if host_state != HttpHostState::Host {
+                        off = i;
+                        len = 0;
+                    }
+                    len += 1;
+                    url.host = Some(
+                        host_buf
+                            .get(off..off + len)
+                            .ok_or(ParseError::Invalid)?,
+                    );
+                }
+                HttpHostState::Hostv6 => {
+                    if host_state != HttpHostState::Hostv6 {
+                        off = i;
+                    }
+                    len += 1;
+                    url.host = Some(
+                        host_buf
+                            .get(off..off + len)
+                            .ok_or(ParseError::Invalid)?,
+                    );
+                }
+                HttpHostState::Hostv6ZoneStart | HttpHostState::Hostv6Zone => {
+                    len += 1;
+                    url.host = Some(
+                        host_buf
+                            .get(off..off + len)
+                            .ok_or(ParseError::Invalid)?,
+                    );
+                }
+                HttpHostState::HostPort => {
+                    if host_state != HttpHostState::HostPort {
+                        off = i;
+                        len = 0;
+                    }
+                    len += 1;
+                    url.port = Some(
+                        host_buf
+                            .get(off..off + len)
+                            .ok_or(ParseError::Invalid)?,
+                    );
+                }
+                HttpHostState::Userinfo => {
+                    if host_state != HttpHostState::Userinfo {
+                        off = i;
+                        len = 0;
+                    }
+                    len += 1;
+                    url.userinfo = Some(
+                        host_buf
+                            .get(off..off + len)
+                            .ok_or(ParseError::Invalid)?,
+                    );
+                }
+                _ => {}
+            }
+            host_state = new_host_state;
+        }
+
+        // Make sure we don't end somewhere unexpected
+        match host_state {
+            HttpHostState::HostStart
+            | HttpHostState::Hostv6Start
+            | HttpHostState::Hostv6
+            | HttpHostState::Hostv6ZoneStart
+            | HttpHostState::Hostv6Zone
+            | HttpHostState::HostPortStart
+            | HttpHostState::Userinfo
+            | HttpHostState::UserinfoStart => {
+                return Err(ParseError::Invalid);
+            }
+            _ => {}
+        }
+    }
+
+    if is_connect
+        && (url.scheme.is_some()
+            || url.path.is_some()
+            || url.query.is_some()
+            || url.fragment.is_some()
+            || url.userinfo.is_some())
+    {
+        return Err(ParseError::InvalidConnect);
+    }
+
+    Ok(url)
+}
+
+#[cfg_attr(feature = "_nopanic", no_panic::no_panic)]
+fn set_url_field<'a>(
+    uf: &UrlFields,
+    mut url: &mut Url<'a>,
+    value: Option<&'a str>,
+) {
+    match uf {
+        UrlFields::Scheme => url.scheme = value,
+        UrlFields::Host => url.host = value,
+        UrlFields::Path => url.path = value,
+        UrlFields::Query => url.query = value,
+        UrlFields::Fragment => url.fragment = value,
+    };
+}
+
+#[cfg_attr(feature = "_nopanic", no_panic::no_panic)]
+fn is_mark(c: char) -> bool {
+    c == '-'
+        || c == '_'
+        || c == '.'
+        || c == '!'
+        || c == '~'
+        || c == '*'
+        || c == '\''
+        || c == '('
+        || c == ')'
+}
+
+#[cfg_attr(feature = "_nopanic", no_panic::no_panic)]
+fn is_userinfo_char(c: char) -> bool {
+    c.is_ascii_alphanumeric()
+        || is_mark(c)
+        || c == '%'
+        || c == ';'
+        || c == ':'
+        || c == '&'
+        || c == '='
+        || c == '+'
+        || c == '$'
+        || c == ','
+}
+
+#[cfg_attr(feature = "_nopanic", no_panic::no_panic)]
+fn is_url_char(c: char) -> bool {
+    !matches!(c, '\0'..='\u{001F}' | '#' | '?' | '\x7F')
+}
+
+#[cfg_attr(feature = "_nopanic", no_panic::no_panic)]
+fn parse_url_start(ch: char) -> Result<State, ParseError> {
+    // Proxied requests are followed by scheme of an absolute URI (alpha).
+    // All methods except CONNECT are followed by '/' or '*'.
+    if ch == '/' || ch == '*' {
+        return Ok(State::Path);
+    }
+
+    if ch.is_ascii_alphabetic() {
+        return Ok(State::Scheme);
+    }
+
+    Err(ParseError::Invalid)
+}
+
+#[cfg_attr(feature = "_nopanic", no_panic::no_panic)]
+fn parse_url_char(state: State, ch: char) -> Result<State, ParseError> {
+    match state {
+        State::Scheme => {
+            if ch.is_ascii_alphabetic() {
+                return Ok(state);
+            }
+
+            if ch == ':' {
+                return Ok(State::SchemeSlash);
+            }
+        }
+        State::SchemeSlash => {
+            if ch == '/' {
+                return Ok(State::SchemeSlashSlash);
+            }
+        }
+        State::SchemeSlashSlash => {
+            if ch == '/' {
+                return Ok(State::ServerStart);
+            }
+        }
+        State::ServerWithAt | State::ServerStart | State::Server => {
+            if state == State::ServerWithAt && ch == '@' {
+                return Err(ParseError::Invalid);
+            }
+
+            if ch == '/' {
+                return Ok(State::Path);
+            }
+
+            if ch == '?' {
+                return Ok(State::QueryStringStart);
+            }
+
+            if ch == '@' {
+                return Ok(State::ServerWithAt);
+            }
+
+            if is_userinfo_char(ch) || ch == '[' || ch == ']' {
+                return Ok(State::Server);
+            }
+        }
+        State::Path => {
+            if is_url_char(ch) {
+                return Ok(state);
+            }
+
+            if ch == '?' {
+                return Ok(State::QueryStringStart);
+            }
+
+            if ch == '#' {
+                return Ok(State::FragmentStart);
+            }
+        }
+        State::QueryStringStart | State::QueryString => {
+            if is_url_char(ch) {
+                return Ok(State::QueryString);
+            }
+
+            if ch == '?' {
+                // allow extra '?' in query string
+                return Ok(State::QueryString);
+            }
+
+            if ch == '#' {
+                return Ok(State::FragmentStart);
+            }
+        }
+        State::FragmentStart => {
+            if is_url_char(ch) {
+                return Ok(State::Fragment);
+            }
+        }
+        State::Fragment => {
+            if is_url_char(ch) {
+                return Ok(state);
+            }
+        }
+    };
+
+    // We should never fall out of the switch above unless there's an error
+    Err(ParseError::Invalid)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum HttpHostState {
+    UserinfoStart,
+    Userinfo,
+    HostStart,
+    Hostv6Start,
+    Host,
+    Hostv6,
+    Hostv6End,
+    Hostv6ZoneStart,
+    Hostv6Zone,
+    HostPortStart,
+    HostPort,
+}
+
+#[cfg_attr(feature = "_nopanic", no_panic::no_panic)]
+fn is_host_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '.' || c == '-'
+}
+
+#[cfg_attr(feature = "_nopanic", no_panic::no_panic)]
+fn parse_host_char(
+    s: &HttpHostState,
+    ch: char,
+) -> Result<HttpHostState, ParseError> {
+    match s {
+        HttpHostState::Userinfo | HttpHostState::UserinfoStart => {
+            if ch == '@' {
+                return Ok(HttpHostState::HostStart);
+            }
+
+            if is_userinfo_char(ch) {
+                return Ok(HttpHostState::Userinfo);
+            }
+        }
+        HttpHostState::HostStart => {
+            if ch == '[' {
+                return Ok(HttpHostState::Hostv6Start);
+            }
+
+            if is_host_char(ch) {
+                return Ok(HttpHostState::Host);
+            }
+        }
+        HttpHostState::Host => {
+            if is_host_char(ch) {
+                return Ok(HttpHostState::Host);
+            }
+            if ch == ':' {
+                return Ok(HttpHostState::HostPortStart);
+            }
+        }
+        HttpHostState::Hostv6End => {
+            if ch == ':' {
+                return Ok(HttpHostState::HostPortStart);
+            }
+        }
+        HttpHostState::Hostv6 | HttpHostState::Hostv6Start => {
+            if s == &HttpHostState::Hostv6 && ch == ']' {
+                return Ok(HttpHostState::Hostv6End);
+            }
+
+            if ch.is_ascii_hexdigit() || ch == ':' || ch == '.' {
+                return Ok(HttpHostState::Hostv6);
+            }
+
+            if s == &HttpHostState::Hostv6 && ch == '%' {
+                return Ok(HttpHostState::Hostv6ZoneStart);
+            }
+        }
+        HttpHostState::Hostv6Zone | HttpHostState::Hostv6ZoneStart => {
+            if s == &HttpHostState::Hostv6Zone && ch == ']' {
+                return Ok(HttpHostState::Hostv6End);
+            }
+
+            // RFC 6874 Zone ID consists of 1*( unreserved / pct-encoded)
+            if ch.is_ascii_alphanumeric()
+                || ch == '%'
+                || ch == '.'
+                || ch == '-'
+                || ch == '_'
+                || ch == '~'
+            {
+                return Ok(HttpHostState::Hostv6Zone);
+            }
+        }
+        HttpHostState::HostPort | HttpHostState::HostPortStart => {
+            if ch.is_ascii_digit() {
+                return Ok(HttpHostState::HostPort);
+            }
+        }
+    }
+
+    Err(ParseError::Invalid)
+}

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -747,17 +747,14 @@ fn is_root_domain(url: &str, expect: &str) {
 
 #[test]
 fn protocol_index_works() {
-    assert_eq!(URAuthParser::<Test>::protocol_index_from_uri("instagram.com"), None);
-    assert_eq!(URAuthParser::<Test>::protocol_index_from_uri("ftp://instagram.com"), Some(5));
-    assert_eq!(URAuthParser::<Test>::protocol_index_from_uri("smtp://instagram.com"), Some(6));
+    assert_eq!(URAuthParser::<Test>::uri_index_without_protocol("instagram.com"), 0);
+    assert_eq!(URAuthParser::<Test>::uri_index_without_protocol("ftp://instagram.com"), 6);
+    assert_eq!(URAuthParser::<Test>::uri_index_without_protocol("smtp://instagram.com"), 7);
 }
 
 #[test]
 fn parent_uris_works() {
     new_test_ext().execute_with(|| {
-        assert!(URAuthParser::<Test>::try_check_owner("instagram.com/user/1", "instagram.com", Alice.to_account_id()).is_err());
-        assert!(URAuthParser::<Test>::try_check_owner("sub2.sub1.instagram.com/user/1", "instagram.com", Alice.to_account_id()).is_err());
-        assert!(URAuthParser::<Test>::try_check_owner("instagram.com", "instagram.com", Alice.to_account_id()).is_err());
+        
     })
 }
-

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -726,12 +726,6 @@ fn parser_works() {
     is_root_domain("ftp://instagram.com", "ftp://instagram.com");
     is_root_domain("ftp://sub2.sub1.www.instagram.com", "ftp://instagram.com");
     is_root_domain("smtp://sub2.sub1.www.instagram.com", "smtp://instagram.com");
-    
-    // assert!(<URAuthParser<Test> as Parser<Test>>::parent_uris("https://instagram.com".as_bytes().to_vec()).unwrap().is_none());
-    // assert!(<URAuthParser<Test> as Parser<Test>>::parent_uris("https://sub1.instagram.com".as_bytes().to_vec()).unwrap().is_none());
-    // assert!(<URAuthParser<Test> as Parser<Test>>::parent_uris("https://sub1.instagram.com/user".as_bytes().to_vec()).unwrap().is_none());
-    // assert!(<URAuthParser<Test> as Parser<Test>>::parent_uris_2("https://instagram.com/user/1".as_bytes().to_vec()).unwrap().is_none());
-    println!("{:?}", URAuthParser::<Test>::parent_uris_2("instagram.com/user/1").unwrap());
 }
 
 fn is_root_domain(url: &str, expect: &str) {
@@ -759,33 +753,11 @@ fn protocol_index_works() {
 }
 
 #[test]
-fn parser_works2(){
-    println!("{:?}", parse_paths("sub2.sub1.instagram.com/user/1"));
-}
-
-fn parse_paths(base_uri: &str) -> Vec<&str> {
-    let mut parent_uris = Vec::new();
-
-    let mut uri = base_uri.clone();
-    while uri.len() > 0 {
-        // Remove the last path segment.
-        match uri.rfind('/') {
-            Some(i) => {
-                uri = &uri[0..i]
-            },
-            None => {
-                match uri.rfind('.') {
-                    Some(d) => {
-                        uri = &uri[d..uri.len()];
-                    }, 
-                    None => { break }
-                }
-            }
-        }
-        // Add the parent URI to the vector.
-        parent_uris.push(uri);
-    }
-
-    return parent_uris;
+fn parent_uris_works() {
+    new_test_ext().execute_with(|| {
+        assert!(URAuthParser::<Test>::try_check_owner("instagram.com/user/1", "instagram.com", Alice.to_account_id()).is_err());
+        assert!(URAuthParser::<Test>::try_check_owner("sub2.sub1.instagram.com/user/1", "instagram.com", Alice.to_account_id()).is_err());
+        assert!(URAuthParser::<Test>::try_check_owner("instagram.com", "instagram.com", Alice.to_account_id()).is_err());
+    })
 }
 

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -655,8 +655,11 @@ fn register_dataset_works() {
 
 #[test]
 fn max_encoded_len() {
+    println!("{:?}", IdentityInfo::max_encoded_len());
+    println!("{:?}", Rule::max_encoded_len());
+    println!("{:?}", AccessRule::max_encoded_len());
     println!(
-        "URAUTH DOCUMENT SIZE is {:?} KB",
-        URAuthDoc::<AccountId32>::max_encoded_len() as f32 / 1_000f32
+        "MAX URAUTH DOCUMENT SIZE is {:?} MB",
+        URAuthDoc::<AccountId32>::max_encoded_len() as f32 / 1_000_000f32
     );
 }

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -20,7 +20,7 @@ fn request_register_ownership_works() {
     let request_call = RequestCall::new(
         RuntimeOrigin::signed(Alice.to_account_id()),
         ClaimType::WebsiteDomain,
-        "www.website1.com".as_bytes().to_vec(),
+        uri,
         URIRequestType::Oracle { is_root: true },
         owner_did.clone(),
         Some(urauth_helper.challenge_value()),
@@ -145,7 +145,8 @@ fn verify_challenge_works() {
             }
             .into(),
         );
-        let urauth_doc = URAuthTree::<Test>::get(&bounded_uri).unwrap();
+        let register_uri: URI = "website1.com".as_bytes().to_vec().try_into().unwrap();
+        let urauth_doc = URAuthTree::<Test>::get(&register_uri).unwrap();
         debug_doc(&urauth_doc);
     });
 }
@@ -192,8 +193,9 @@ fn update_urauth_doc_works() {
             RuntimeOrigin::signed(Alice.to_account_id()),
             challenge_value
         ));
-
-        let mut urauth_doc = URAuthTree::<Test>::get(&bounded_uri).unwrap();
+        
+        let register_uri: URI = "website1.com".as_bytes().to_vec().try_into().unwrap();
+        let mut urauth_doc = URAuthTree::<Test>::get(&register_uri).unwrap();
         debug_doc(&urauth_doc);
 
         let update_doc_field = UpdateDocField::AccessRules(None);
@@ -201,14 +203,14 @@ fn update_urauth_doc_works() {
         let update_signature = urauth_helper.create_sr25519_signature(
             Alice,
             ProofType::Update(
-                bounded_uri.clone(),
+                register_uri.clone(),
                 urauth_doc.clone(),
                 bounded_owner_did.clone(),
             ),
         );
         assert_ok!(URAuth::update_urauth_doc(
             RuntimeOrigin::signed(Alice.to_account_id()),
-            bounded_uri.clone(),
+            register_uri.clone(),
             update_doc_field,
             1u128,
             Some(Proof::ProofV1 {
@@ -236,14 +238,14 @@ fn update_urauth_doc_works() {
         let update_signature = urauth_helper.create_sr25519_signature(
             Alice,
             ProofType::Update(
-                bounded_uri.clone(),
+                register_uri.clone(),
                 urauth_doc.clone(),
                 bounded_owner_did.clone(),
             ),
         );
         assert_ok!(URAuth::update_urauth_doc(
             RuntimeOrigin::signed(Alice.to_account_id()),
-            bounded_uri.clone(),
+            register_uri.clone(),
             update_doc_field,
             2u128,
             Some(Proof::ProofV1 {
@@ -251,7 +253,7 @@ fn update_urauth_doc_works() {
                 proof: update_signature.into()
             })
         ));
-        let mut urauth_doc = URAuthTree::<Test>::get(&bounded_uri).unwrap();
+        let mut urauth_doc = URAuthTree::<Test>::get(&register_uri).unwrap();
         debug_doc(&urauth_doc);
 
         let update_doc_field = UpdateDocField::MultiDID(WeightedDID {
@@ -262,14 +264,14 @@ fn update_urauth_doc_works() {
         let update_signature = urauth_helper.create_sr25519_signature(
             Alice,
             ProofType::Update(
-                bounded_uri.clone(),
+                register_uri.clone(),
                 urauth_doc.clone(),
                 bounded_owner_did.clone(),
             ),
         );
         assert_ok!(URAuth::update_urauth_doc(
             RuntimeOrigin::signed(Alice.to_account_id()),
-            bounded_uri.clone(),
+            register_uri.clone(),
             update_doc_field,
             3u128,
             Some(Proof::ProofV1 {
@@ -278,7 +280,7 @@ fn update_urauth_doc_works() {
             })
         ));
 
-        let mut urauth_doc = URAuthTree::<Test>::get(&bounded_uri).unwrap();
+        let mut urauth_doc = URAuthTree::<Test>::get(&register_uri).unwrap();
         debug_doc(&urauth_doc);
 
         let update_doc_field = UpdateDocField::<MockAccountId>::Threshold(2);
@@ -286,14 +288,14 @@ fn update_urauth_doc_works() {
         let update_signature = urauth_helper.create_sr25519_signature(
             Alice,
             ProofType::Update(
-                bounded_uri.clone(),
+                register_uri.clone(),
                 urauth_doc.clone(),
                 bounded_owner_did.clone(),
             ),
         );
         assert_ok!(URAuth::update_urauth_doc(
             RuntimeOrigin::signed(Alice.to_account_id()),
-            bounded_uri.clone(),
+            register_uri.clone(),
             update_doc_field,
             4u128,
             Some(Proof::ProofV1 {
@@ -302,7 +304,7 @@ fn update_urauth_doc_works() {
             })
         ));
 
-        let mut urauth_doc = URAuthTree::<Test>::get(&bounded_uri).unwrap();
+        let mut urauth_doc = URAuthTree::<Test>::get(&register_uri).unwrap();
         debug_doc(&urauth_doc);
 
         let update_doc_field = UpdateDocField::MultiDID(WeightedDID {
@@ -313,7 +315,7 @@ fn update_urauth_doc_works() {
         let update_signature = urauth_helper.create_sr25519_signature(
             Alice,
             ProofType::Update(
-                bounded_uri.clone(),
+                register_uri.clone(),
                 urauth_doc.clone(),
                 bounded_owner_did.clone(),
             ),
@@ -324,7 +326,7 @@ fn update_urauth_doc_works() {
         };
         assert_ok!(URAuth::update_urauth_doc(
             RuntimeOrigin::signed(Alice.to_account_id()),
-            bounded_uri.clone(),
+            register_uri.clone(),
             update_doc_field,
             5,
             Some(Proof::ProofV1 {
@@ -356,7 +358,7 @@ fn update_urauth_doc_works() {
 
         // Since threhold is 2, URAUTH Document has not been updated.
         // Bob should sign for update.
-        let mut urauth_doc = URAuthTree::<Test>::get(&bounded_uri).unwrap();
+        let mut urauth_doc = URAuthTree::<Test>::get(&register_uri).unwrap();
 
         let update_doc_field = UpdateDocField::MultiDID(WeightedDID {
             did: Charlie.to_account_id(),
@@ -371,11 +373,11 @@ fn update_urauth_doc_works() {
             .expect("Too long");
         let update_signature = urauth_helper.create_sr25519_signature(
             Bob,
-            ProofType::Update(bounded_uri.clone(), urauth_doc.clone(), bob_did.clone()),
+            ProofType::Update(register_uri.clone(), urauth_doc.clone(), bob_did.clone()),
         );
         assert_ok!(URAuth::update_urauth_doc(
             RuntimeOrigin::signed(Bob.to_account_id()),
-            bounded_uri.clone(),
+            register_uri.clone(),
             update_doc_field,
             5,
             Some(Proof::ProofV1 {
@@ -384,7 +386,7 @@ fn update_urauth_doc_works() {
             })
         ));
 
-        let urauth_doc = URAuthTree::<Test>::get(&bounded_uri).unwrap();
+        let urauth_doc = URAuthTree::<Test>::get(&register_uri).unwrap();
         debug_doc(&urauth_doc);
         let proofs = urauth_doc.clone().proofs.unwrap();
         for proof in proofs {
@@ -484,74 +486,6 @@ fn verify_challenge_with_multiple_oracle_members() {
 }
 
 #[test]
-fn claim_file_ownership_works() {
-    new_test_ext().execute_with(|| {
-        let mut urauth_helper = MockURAuthHelper::<AccountId32>::default(None, None, None, None);
-        let (_, owner_did, _, _) = urauth_helper.deconstruct_urauth_doc(None);
-        let bounded_uri = urauth_helper.bounded_uri(Some("urauth://file".into()));
-        let bounded_owner_did = urauth_helper.raw_owner_did();
-        let request_sig = urauth_helper.create_signature(
-            Alice,
-            ProofType::Request(bounded_uri.clone(), bounded_owner_did.clone()),
-        );
-        assert_ok!(URAuth::claim_ownership(
-            RuntimeOrigin::signed(Alice.to_account_id()),
-            ClaimType::File,
-            "urauth://file".into(),
-            URIRequestType::Any {
-                maybe_parent_acc: Alice.to_account_id()
-            },
-            owner_did,
-            MultiSigner::Sr25519(Alice.public()),
-            request_sig
-        ));
-        let urauth_doc = URAuthTree::<Test>::get(&bounded_uri);
-        println!("{:?}", urauth_doc);
-        println!(
-            "Size of URAUTH DOCUMENT => {:?} bytes",
-            urauth_doc.encode().len()
-        );
-    })
-}
-
-#[test]
-fn register_dataset_works() {
-    new_test_ext().execute_with(|| {
-        let mut urauth_helper = MockURAuthHelper::<AccountId32>::default(None, None, None, None);
-        let (_, owner_did, _, _) = urauth_helper.deconstruct_urauth_doc(None);
-        let bounded_uri = urauth_helper.bounded_uri(Some("urauth://file".into()));
-        let bounded_owner_did = urauth_helper.raw_owner_did();
-        let request_sig = urauth_helper.create_signature(
-            Alice,
-            ProofType::Request(bounded_uri.clone(), bounded_owner_did.clone()),
-        );
-
-        assert_ok!(URAuth::claim_ownership(
-            RuntimeOrigin::signed(Alice.to_account_id()),
-            ClaimType::Dataset {
-                data_source: Some("ipfs://{SHA256}".into()),
-                name: "".into(),
-                description: "".into()
-            },
-            "urauth://dataset/{CID}".into(),
-            URIRequestType::Any {
-                maybe_parent_acc: Alice.to_account_id()
-            },
-            owner_did,
-            MultiSigner::Sr25519(Alice.public()),
-            request_sig,
-        ));
-
-        let urauth_doc = URAuthTree::<Test>::get(&bounded_uri);
-        println!("{:?}", urauth_doc);
-        println!(
-            "Size of URAUTH DOCUMENT is {:?} b",
-            urauth_doc.encode().len() as f32
-        );
-    })
-}
-
-#[test]
 fn integrity_test() {
     let mut urauth_helper = MockURAuthHelper::<AccountId32>::default(None, None, None, None);
     let (uri, owner_did, challenge_value, timestamp) = urauth_helper.deconstruct_urauth_doc(None);
@@ -598,7 +532,8 @@ fn integrity_test() {
             request_call
                 .clone()
                 .set_request_type(URIRequestType::Any {
-                    maybe_parent_acc: Alice.to_account_id()
+                    is_root: true,
+                    maybe_parent_acc: None
                 })
                 .runtime_call(),
             Error::<Test>::BadClaim
@@ -628,7 +563,9 @@ fn integrity_test() {
         let urauth_doc = URAuthTree::<Test>::get(&reigstered_uri).unwrap();
         debug_doc(&urauth_doc);
         let uri = "sub2.sub1.website1.com".as_bytes().to_vec();
-
+        // Registered URI should not be requested.
+        assert_noop!(request_call.clone().runtime_call(), Error::<Test>::AlreadyRegistered);
+        
         // Parent should be Alice
         assert_noop!(
             request_call
@@ -636,7 +573,8 @@ fn integrity_test() {
                 .set_challenge(None)
                 .set_uri(uri.clone())
                 .set_request_type(URIRequestType::Any {
-                    maybe_parent_acc: Bob.to_account_id()
+                    is_root: false,
+                    maybe_parent_acc: Some(Bob.to_account_id())
                 })
                 .runtime_call(),
             Error::<Test>::NotURAuthDocOwner
@@ -651,7 +589,8 @@ fn integrity_test() {
             .set_signer(Bob.into())
             .set_owner_did(bob_did.clone())
             .set_request_type(URIRequestType::Any {
-                maybe_parent_acc: Alice.to_account_id()
+                is_root: false,
+                maybe_parent_acc: Some(Alice.to_account_id())
             })
             .set_sig(urauth_helper.create_signature(
                 Bob,
@@ -738,5 +677,69 @@ fn integrity_test() {
                 )
             ))
             .runtime_call());
+        let uri = "urauth://file/cid".as_bytes().to_vec();
+        assert_ok!(request_call
+            .clone()
+            .set_challenge(None)
+            .set_claim_type(ClaimType::File)
+            .set_request_type(URIRequestType::Any { is_root: true, maybe_parent_acc: None })
+            .set_uri(uri.clone())
+            .set_sig(urauth_helper.create_signature(
+                Alice, 
+                ProofType::Request(
+                    uri.try_into().unwrap(), 
+                    owner_did.clone().try_into().unwrap()
+                )
+            ))
+            .runtime_call()
+        );
+        let uri = "urauth://file/cid/1".as_bytes().to_vec();
+        assert_noop!(request_call
+            .clone()
+            .set_challenge(None)
+            .set_claim_type(ClaimType::File)
+            .set_request_type(URIRequestType::Any { is_root: true, maybe_parent_acc: None })
+            .set_uri(uri.clone())
+            .set_sig(urauth_helper.create_signature(
+                Alice, 
+                ProofType::Request(
+                    uri.clone().try_into().unwrap(), 
+                    owner_did.clone().try_into().unwrap()
+                )
+            ))
+            .runtime_call(),
+            Error::<Test>::NotRootURI
+        );
+        assert_noop!(request_call
+            .clone()
+            .set_challenge(None)
+            .set_claim_type(ClaimType::File)
+            .set_request_type(URIRequestType::Any { is_root: false, maybe_parent_acc: Some(Bob.to_account_id()) })
+            .set_uri(uri.clone())
+            .set_sig(urauth_helper.create_signature(
+                Alice, 
+                ProofType::Request(
+                    uri.clone().try_into().unwrap(), 
+                    owner_did.clone().try_into().unwrap()
+                )
+            ))
+            .runtime_call(),
+            Error::<Test>::NotURAuthDocOwner
+        );
+        assert_ok!(request_call
+            .clone()
+            .set_challenge(None)
+            .set_claim_type(ClaimType::File)
+            .set_request_type(URIRequestType::Any { is_root: false, maybe_parent_acc: Some(Alice.to_account_id()) })
+            .set_uri(uri.clone())
+            .set_sig(urauth_helper.create_signature(
+                Alice, 
+                ProofType::Request(
+                    uri.try_into().unwrap(), 
+                    owner_did.clone().try_into().unwrap()
+                )
+            ))
+            .runtime_call()
+        );
     })
 }

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -757,7 +757,14 @@ fn is_base_url(url: &str, expect: &str) {
     let urauth_helper = MockURAuthHelper::<AccountId32>::default(None, None, None, None);
     let url: String = url.into();
     let raw_url: Vec<u8> = url.clone().into();
-    let uri = <URAuthParser as Parser<Test>>::base_uri(raw_url).unwrap();
-    println!(" Given URI is base uri => {:?}", url);
-    assert_eq!(uri, urauth_helper.bounded_uri(Some(expect.into())));
+    match <URAuthParser as Parser<Test>>::base_uri(raw_url) {
+        Ok(uri) => {
+            println!(" Given URI is base uri => {:?}", url);
+            assert_eq!(uri, urauth_helper.bounded_uri(Some(expect.into())));
+        },
+        Err(_) => { 
+            println!(" Given URI is not base uri => {:?}", url);
+            return 
+        }
+    }
 }

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -18,11 +18,10 @@ fn request_register_ownership_works() {
         ),
     );
     new_test_ext().execute_with(|| {
-
         assert_ok!(URAuth::add_uri_by_oracle(
-            RuntimeOrigin::root(), 
+            RuntimeOrigin::root(),
             ClaimType::WebsiteDomain,
-            URIRequestType::Oracle { is_root: true }, 
+            URIRequestType::Oracle { is_root: true },
             "https://www.website1.com".into()
         ));
 
@@ -517,7 +516,9 @@ fn claim_file_ownership_works() {
             RuntimeOrigin::signed(Alice.to_account_id()),
             ClaimType::File,
             "urauth://file".into(),
-            URIRequestType::Any { maybe_parent_acc: Alice.to_account_id() },
+            URIRequestType::Any {
+                maybe_parent_acc: Alice.to_account_id()
+            },
             owner_did,
             MultiSigner::Sr25519(Alice.public()),
             request_sig
@@ -551,7 +552,9 @@ fn register_dataset_works() {
                 description: "".into()
             },
             "urauth://dataset/{CID}".into(),
-            URIRequestType::Any { maybe_parent_acc: Alice.to_account_id() },
+            URIRequestType::Any {
+                maybe_parent_acc: Alice.to_account_id()
+            },
             owner_did,
             MultiSigner::Sr25519(Alice.public()),
             request_sig,
@@ -600,9 +603,9 @@ fn integrity_test() {
         owner_did.clone(),
         Some(urauth_helper.challenge_value()),
         signer.clone(),
-        r_sig.clone()
+        r_sig.clone(),
     );
-    
+
     new_test_ext().execute_with(|| {
         assert_ok!(URAuth::add_oracle_member(
             RuntimeOrigin::root(),
@@ -611,23 +614,28 @@ fn integrity_test() {
         // Request type should be 'Oracle'
         assert_noop!(
             request_call
-            .clone()
-            .set_request_type(URIRequestType::Any { maybe_parent_acc: Alice.to_account_id() })
-            .runtime_call(), Error::<Test>::BadClaim
+                .clone()
+                .set_request_type(URIRequestType::Any {
+                    maybe_parent_acc: Alice.to_account_id()
+                })
+                .runtime_call(),
+            Error::<Test>::BadClaim
         );
         // Domain without host should fail
         assert_noop!(
             request_call
-            .clone()
-            .set_uri("news:comp.infosystems".as_bytes().to_vec())
-            .runtime_call(), Error::<Test>::BadClaim
+                .clone()
+                .set_uri("news:comp.infosystems".as_bytes().to_vec())
+                .runtime_call(),
+            Error::<Test>::BadClaim
         );
         // URI which is not root should fail
         assert_noop!(
             request_call
-            .clone()
-            .set_uri("sub1.website1.com".as_bytes().to_vec())
-            .runtime_call(), Error::<Test>::NotRootURI
+                .clone()
+                .set_uri("sub1.website1.com".as_bytes().to_vec())
+                .runtime_call(),
+            Error::<Test>::NotRootURI
         );
         assert_ok!(request_call.runtime_call());
     })

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -761,9 +761,11 @@ fn integrity_test() {
         assert_ok!(request_call
             .clone()
             .set_uri(uri.clone())
-            .set_sig(urauth_helper.create_signature(Alice, ProofType::Request(bounded_uri.clone(), owner_did.try_into().unwrap())))
-            .runtime_call()
-        );
+            .set_sig(urauth_helper.create_signature(
+                Alice,
+                ProofType::Request(bounded_uri.clone(), owner_did.try_into().unwrap())
+            ))
+            .runtime_call());
         run_to_block(5);
         assert!(Metadata::<Test>::get(&bounded_uri).is_none());
         assert!(URIVerificationInfo::<Test>::get(&bounded_uri).is_none());

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -155,6 +155,7 @@ fn urauth_request_register_ownership_works() {
             "www.website1.com".as_bytes().to_vec(),
             owner_did.clone(),
             Some(urauth_helper.challenge_value()),
+            ClaimType::WebsiteDomain,
             signer.clone(),
             signature.clone()
         ));
@@ -177,6 +178,7 @@ fn urauth_request_register_ownership_works() {
                 uri.clone(),
                 urauth_helper.generate_did(BOB_SS58).as_bytes().to_vec(),
                 Some(urauth_helper.challenge_value()),
+                ClaimType::WebsiteDomain,
                 signer.clone(),
                 signature.clone()
             ),
@@ -198,6 +200,7 @@ fn urauth_request_register_ownership_works() {
                 uri.clone(),
                 owner_did.clone(),
                 Some(urauth_helper.challenge_value()),
+                ClaimType::WebsiteDomain,
                 signer.clone(),
                 signature2
             ),
@@ -222,6 +225,7 @@ fn urauth_request_register_ownership_works() {
                 uri.clone(),
                 owner_did,
                 Some(urauth_helper.challenge_value()),
+                ClaimType::WebsiteDomain,
                 signer.clone(),
                 signature3
             ),
@@ -262,6 +266,7 @@ fn verify_challenge_works() {
             uri.clone(),
             owner_did,
             Some(urauth_helper.challenge_value()),
+            ClaimType::WebsiteDomain,
             MultiSigner::Sr25519(Alice.public()),
             request_sig
         ));
@@ -315,6 +320,7 @@ fn update_urauth_doc_works() {
             uri.clone(),
             owner_did.clone(),
             Some(urauth_helper.challenge_value()),
+            ClaimType::WebsiteDomain,
             MultiSigner::Sr25519(Alice.public()),
             request_sig
         ));
@@ -572,6 +578,7 @@ fn verify_challenge_with_multiple_oracle_members() {
             uri.clone(),
             owner_did.clone(),
             Some(urauth_helper.challenge_value()),
+            ClaimType::WebsiteDomain,
             MultiSigner::Sr25519(Alice.public()),
             request_sig
         ));
@@ -708,6 +715,7 @@ fn parse_string_works() {
 
 #[test]
 fn parser_works() {
+    parse_and_check_root("http://instagram.com", "instagram.com");
     parse_and_check_root("https://instagram.com", "instagram.com");
     parse_and_check_root("https://www.instagram.com", "instagram.com");
     parse_and_check_root("https://sub2.sub1.www.instagram.com", "instagram.com");

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -715,7 +715,7 @@ fn parser_works2() {
 
     assert_eq!(
         <URAuthParser as Parser<Test>>::base_uri(
-            &"https://instagram.com/user"
+            "https://instagram.com/user"
                 .as_bytes()
                 .to_vec()
                 .try_into()
@@ -724,19 +724,20 @@ fn parser_works2() {
     );
 }
 
+// cargo t -p pallet-urauth --lib -- tests::parser_works --exact --nocapture 
 #[test]
 fn parser_works() {
 
-    parse_and_check_root("http://instagram.com", "instagram.com");
-    parse_and_check_root("https://instagram.com", "instagram.com");
-    parse_and_check_root("https://www.instagram.com", "instagram.com");
-    parse_and_check_root("https://sub2.sub1.www.instagram.com", "instagram.com");
-    parse_and_check_root("www.instagram.com", "instagram.com");
-    parse_and_check_root("instagram.com", "instagram.com");
-    parse_and_check_root("instagram.com/user", "instagram.com");
-    parse_and_check_root("instagram.com/user/challenge.json", "instagram.com");
-    parse_and_check_root("ftp://sub2.sub1.www.instagram.com", "ftp://instagram.com");
-    parse_and_check_root("smtp://sub2.sub1.www.instagram.com", "smtp://instagram.com");
+    is_base_url("http://instagram.com", "instagram.com");
+    is_base_url("https://instagram.com", "instagram.com");
+    is_base_url("https://www.instagram.com", "instagram.com");
+    is_base_url("https://sub2.sub1.www.instagram.com", "instagram.com");
+    is_base_url("www.instagram.com", "instagram.com");
+    is_base_url("instagram.com", "instagram.com");
+    is_base_url("instagram.com/user", "instagram.com");
+    is_base_url("instagram.com/user/challenge.json", "instagram.com");
+    is_base_url("ftp://sub2.sub1.www.instagram.com", "ftp://instagram.com");
+    is_base_url("smtp://sub2.sub1.www.instagram.com", "smtp://instagram.com");
     
     // assert!(<URAuthParser as Parser<Test>>::parent_uris(&"https://instagram.com".as_bytes().to_vec()).unwrap().is_none());
     // assert!(<URAuthParser as Parser<Test>>::parent_uris(&"https://instagram.com/yoonszone".as_bytes().to_vec()).unwrap().is_some());
@@ -752,11 +753,11 @@ fn parser_works() {
     // );
 }
 
-fn parse_and_check_root(url: &str, expect: &str) {
+fn is_base_url(url: &str, expect: &str) {
     let urauth_helper = MockURAuthHelper::<AccountId32>::default(None, None, None, None);
     let url: String = url.into();
     let raw_url: Vec<u8> = url.clone().into();
-    let uri: URI = raw_url.try_into().expect("Too long");
-    let root_uri = <URAuthParser as Parser<Test>>::base_uri(&uri).unwrap();
-    assert_eq!(root_uri, urauth_helper.bounded_uri(Some(expect.into())));
+    let uri = <URAuthParser as Parser<Test>>::base_uri(raw_url).unwrap();
+    println!(" Given URI is base uri => {:?}", url);
+    assert_eq!(uri, urauth_helper.bounded_uri(Some(expect.into())));
 }

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -663,3 +663,17 @@ fn max_encoded_len() {
         URAuthDoc::<AccountId32>::max_encoded_len() as f32 / 1_000_000f32
     );
 }
+
+#[test]
+fn parse_string_works() {
+    use ada_url::Url;
+    use addr::parse_domain_name;
+
+    let u = Url::parse("http://sub2.sub1.instagram.com/coco/post", None)
+        .expect("bad url");
+    println!("{:?}", u.protocol());
+    println!("{:?}", u.hostname());
+    println!("{:?}", u.pathname());
+    let domain_name = parse_domain_name(u.hostname()).expect("Bad URL");
+    println!("{:?}", domain_name.root());
+}

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -15,7 +15,7 @@ fn request_register_ownership_works() {
         ProofType::Request(
             urauth_helper.bounded_uri(None),
             urauth_helper.raw_owner_did(),
-            1
+            1,
         ),
     );
     let request_call = RequestCall::new(
@@ -205,7 +205,7 @@ fn update_urauth_doc_works() {
                 register_uri.clone(),
                 urauth_doc.clone(),
                 bounded_owner_did.clone(),
-                2
+                2,
             ),
         );
         assert_ok!(URAuth::update_urauth_doc(
@@ -241,7 +241,7 @@ fn update_urauth_doc_works() {
                 register_uri.clone(),
                 urauth_doc.clone(),
                 bounded_owner_did.clone(),
-                3
+                3,
             ),
         );
         assert_ok!(URAuth::update_urauth_doc(
@@ -268,7 +268,7 @@ fn update_urauth_doc_works() {
                 register_uri.clone(),
                 urauth_doc.clone(),
                 bounded_owner_did.clone(),
-                4
+                4,
             ),
         );
         assert_ok!(URAuth::update_urauth_doc(
@@ -293,7 +293,7 @@ fn update_urauth_doc_works() {
                 register_uri.clone(),
                 urauth_doc.clone(),
                 bounded_owner_did.clone(),
-                5
+                5,
             ),
         );
         assert_ok!(URAuth::update_urauth_doc(
@@ -321,7 +321,7 @@ fn update_urauth_doc_works() {
                 register_uri.clone(),
                 urauth_doc.clone(),
                 bounded_owner_did.clone(),
-                6
+                6,
             ),
         );
         let ura_update_proof = Proof::ProofV1 {
@@ -500,7 +500,7 @@ fn integrity_test() {
         ProofType::Request(
             urauth_helper.bounded_uri(None),
             urauth_helper.raw_owner_did(),
-            1
+            1,
         ),
     );
     let c_sig = urauth_helper.create_sr25519_signature(
@@ -622,7 +622,11 @@ fn integrity_test() {
             .set_signer(Bob.into())
             .set_sig(urauth_helper.create_signature(
                 Bob,
-                ProofType::Request(uri.try_into().unwrap(), bob_did.clone().try_into().unwrap(), 1)
+                ProofType::Request(
+                    uri.try_into().unwrap(),
+                    bob_did.clone().try_into().unwrap(),
+                    1
+                )
             ))
             .runtime_call());
         let uri = "website3.com/user".as_bytes().to_vec();
@@ -630,7 +634,7 @@ fn integrity_test() {
         let parent = Bob;
         assert_ok!(URAuth::add_uri_by_oracle(
             RuntimeOrigin::root(),
-            ClaimType::Domain, 
+            ClaimType::Domain,
             "website3.com/feed/*".into()
         ));
         assert_noop!(
@@ -667,7 +671,11 @@ fn integrity_test() {
         assert_ok!(request_call
             .clone()
             .set_challenge(None)
-            .set_claim_type(ClaimType::Contents { data_source: None, name: Default::default(), description: Default::default() })
+            .set_claim_type(ClaimType::Contents {
+                data_source: None,
+                name: Default::default(),
+                description: Default::default()
+            })
             .set_uri(uri.clone())
             .set_sig(urauth_helper.create_signature(
                 Alice,
@@ -683,7 +691,11 @@ fn integrity_test() {
             request_call
                 .clone()
                 .set_challenge(None)
-                .set_claim_type(ClaimType::Contents { data_source: None, name: Default::default(), description: Default::default() })
+                .set_claim_type(ClaimType::Contents {
+                    data_source: None,
+                    name: Default::default(),
+                    description: Default::default()
+                })
                 .set_signer(Bob.into())
                 .set_uri(uri.clone())
                 .set_sig(urauth_helper.create_signature(
@@ -700,7 +712,11 @@ fn integrity_test() {
         assert_ok!(request_call
             .clone()
             .set_challenge(None)
-            .set_claim_type(ClaimType::Contents { data_source: None, name: Default::default(), description: Default::default() })
+            .set_claim_type(ClaimType::Contents {
+                data_source: None,
+                name: Default::default(),
+                description: Default::default()
+            })
             .set_uri(uri.clone())
             .set_sig(urauth_helper.create_signature(
                 Alice,

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -24,7 +24,7 @@ fn find_json_value(
 fn account_id_from_did_raw(mut raw: Vec<u8>) -> AccountId32 {
     let actual_owner_did: Vec<u8> = raw.drain(raw.len() - 48..raw.len()).collect();
     let mut output = bs58::decode(actual_owner_did).into_vec().unwrap();
-    let temp: Vec<u8> = output.drain(1..33).collect();
+                                    let temp: Vec<u8> = output.drain(1..33).collect();
     let mut raw_account_id = [0u8; 32];
     let buf = &temp[..raw_account_id.len()];
     raw_account_id.copy_from_slice(buf);
@@ -70,17 +70,14 @@ fn json_parse_works() {
         }
         _ => {}
     }
-    assert!(domain == "website1.com".as_bytes().to_vec());
-    assert!(
-        admin_did
-            == "did:infra:ua:5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV"
-                .as_bytes()
-                .to_vec()
-    );
-    assert!(challenge == "__random_challenge_value__".as_bytes().to_vec());
-    assert!(timestamp == "2023-07-28T10:17:21Z".as_bytes().to_vec());
-    assert!(proof_type == "Ed25519Signature2020".as_bytes().to_vec());
-    assert!(proof == "gweEDz58DAdFfa9.....CrfFPP2oumHKtz".as_bytes().to_vec());
+    assert_eq!(domain, "website1.com".as_bytes().to_vec());
+    assert_eq!(admin_did, "did:infra:ua:5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV"
+        .as_bytes()
+        .to_vec());
+    assert_eq!(challenge, "__random_challenge_value__".as_bytes().to_vec());
+    assert_eq!(timestamp, "2023-07-28T10:17:21Z".as_bytes().to_vec());
+    assert_eq!(proof_type, "Ed25519Signature2020".as_bytes().to_vec());
+    assert_eq!(proof, "gweEDz58DAdFfa9.....CrfFPP2oumHKtz".as_bytes().to_vec());
     let account_id32 = account_id_from_did_raw(admin_did);
     println!("AccountId32 => {:?}", account_id32);
 }
@@ -101,7 +98,7 @@ fn verification_submission_dynamic_threshold_works() {
 }
 
 #[test]
-fn verfiication_submission_update_status_works() {
+fn verification_submission_update_status_works() {
     // Complete
     let mut s1: VerificationSubmission<Test> = Default::default();
     let h1 = BlakeTwo256::hash(&1u32.to_le_bytes());
@@ -714,6 +711,20 @@ fn parse_string_works() {
 }
 
 #[test]
+fn parser_works2() {
+
+    assert_eq!(
+        <URAuthParser as Parser<Test>>::base_uri(
+            &"https://instagram.com/user"
+                .as_bytes()
+                .to_vec()
+                .try_into()
+                .expect("")
+        ).is_err(), true
+    );
+}
+
+#[test]
 fn parser_works() {
 
     parse_and_check_root("http://instagram.com", "instagram.com");
@@ -727,9 +738,9 @@ fn parser_works() {
     parse_and_check_root("ftp://sub2.sub1.www.instagram.com", "ftp://instagram.com");
     parse_and_check_root("smtp://sub2.sub1.www.instagram.com", "smtp://instagram.com");
     
-    assert!(<URAuthParser as Parser<Test>>::parent_uris(&"https://instagram.com".as_bytes().to_vec()).unwrap().is_none());
-    assert!(<URAuthParser as Parser<Test>>::parent_uris(&"https://instagram.com/yoonszone".as_bytes().to_vec()).unwrap().is_some());
-    assert!(<URAuthParser as Parser<Test>>::parent_uris(&"https://instagram.com/yoonszone/saved".as_bytes().to_vec()).unwrap().is_some());
+    // assert!(<URAuthParser as Parser<Test>>::parent_uris(&"https://instagram.com".as_bytes().to_vec()).unwrap().is_none());
+    // assert!(<URAuthParser as Parser<Test>>::parent_uris(&"https://instagram.com/yoonszone".as_bytes().to_vec()).unwrap().is_some());
+    // assert!(<URAuthParser as Parser<Test>>::parent_uris(&"https://instagram.com/yoonszone/saved".as_bytes().to_vec()).unwrap().is_some());
     // assert_eq!(
     //     <URAuthParser as Parser<Test>>::parent_uris(&"https://instagram.com/yoonszone/saved".as_bytes().to_vec()).unwrap(),
     //     Some(
@@ -745,6 +756,7 @@ fn parse_and_check_root(url: &str, expect: &str) {
     let urauth_helper = MockURAuthHelper::<AccountId32>::default(None, None, None, None);
     let url: String = url.into();
     let raw_url: Vec<u8> = url.clone().into();
-    let root_uri = <URAuthParser as Parser<Test>>::base_uri(&raw_url).unwrap();
-    assert!(root_uri == urauth_helper.bounded_uri(Some(expect.into())));
+    let uri: URI = raw_url.try_into().expect("Too long");
+    let root_uri = <URAuthParser as Parser<Test>>::base_uri(&uri).unwrap();
+    assert_eq!(root_uri, urauth_helper.bounded_uri(Some(expect.into())));
 }

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -147,12 +147,21 @@ fn urauth_request_register_ownership_works() {
         ),
     );
     new_test_ext().execute_with(|| {
+
+        assert_ok!(URAuth::add_uri_by_oracle(
+            RuntimeOrigin::root(), 
+            ClaimType::WebsiteDomain,
+            URIRequestType::Oracle { is_root: true }, 
+            "website1.com".into()
+        ));
+
         assert_ok!(URAuth::urauth_request_register_ownership(
             RuntimeOrigin::signed(Alice.to_account_id()),
+            ClaimType::WebsiteDomain,
             "www.website1.com".as_bytes().to_vec(),
+            URIRequestType::Oracle { is_root: true },
             owner_did.clone(),
             Some(urauth_helper.challenge_value()),
-            ClaimType::WebsiteDomain,
             signer.clone(),
             signature.clone()
         ));
@@ -172,10 +181,11 @@ fn urauth_request_register_ownership_works() {
         assert_noop!(
             URAuth::urauth_request_register_ownership(
                 RuntimeOrigin::signed(Alice.to_account_id()),
+                ClaimType::WebsiteDomain,
                 uri.clone(),
+                URIRequestType::Oracle { is_root: true },
                 urauth_helper.generate_did(BOB_SS58).as_bytes().to_vec(),
                 Some(urauth_helper.challenge_value()),
-                ClaimType::WebsiteDomain,
                 signer.clone(),
                 signature.clone()
             ),
@@ -194,10 +204,11 @@ fn urauth_request_register_ownership_works() {
         assert_noop!(
             URAuth::urauth_request_register_ownership(
                 RuntimeOrigin::signed(Alice.to_account_id()),
+                ClaimType::WebsiteDomain,
                 uri.clone(),
+                URIRequestType::Oracle { is_root: true },
                 owner_did.clone(),
                 Some(urauth_helper.challenge_value()),
-                ClaimType::WebsiteDomain,
                 signer.clone(),
                 signature2
             ),
@@ -219,10 +230,11 @@ fn urauth_request_register_ownership_works() {
         assert_noop!(
             URAuth::urauth_request_register_ownership(
                 RuntimeOrigin::signed(Alice.to_account_id()),
+                ClaimType::WebsiteDomain,
                 uri.clone(),
+                URIRequestType::Oracle { is_root: true },
                 owner_did,
                 Some(urauth_helper.challenge_value()),
-                ClaimType::WebsiteDomain,
                 signer.clone(),
                 signature3
             ),
@@ -260,10 +272,11 @@ fn verify_challenge_works() {
 
         assert_ok!(URAuth::urauth_request_register_ownership(
             RuntimeOrigin::signed(Alice.to_account_id()),
+            ClaimType::WebsiteDomain,
             uri.clone(),
+            URIRequestType::Oracle { is_root: true },
             owner_did,
             Some(urauth_helper.challenge_value()),
-            ClaimType::WebsiteDomain,
             MultiSigner::Sr25519(Alice.public()),
             request_sig
         ));
@@ -314,10 +327,11 @@ fn update_urauth_doc_works() {
 
         assert_ok!(URAuth::urauth_request_register_ownership(
             RuntimeOrigin::signed(Alice.to_account_id()),
+            ClaimType::WebsiteDomain,
             uri.clone(),
+            URIRequestType::Oracle { is_root: true },
             owner_did.clone(),
             Some(urauth_helper.challenge_value()),
-            ClaimType::WebsiteDomain,
             MultiSigner::Sr25519(Alice.public()),
             request_sig
         ));
@@ -572,10 +586,11 @@ fn verify_challenge_with_multiple_oracle_members() {
 
         assert_ok!(URAuth::urauth_request_register_ownership(
             RuntimeOrigin::signed(Alice.to_account_id()),
+            ClaimType::WebsiteDomain,
             uri.clone(),
+            URIRequestType::Oracle { is_root: true },
             owner_did.clone(),
             Some(urauth_helper.challenge_value()),
-            ClaimType::WebsiteDomain,
             MultiSigner::Sr25519(Alice.public()),
             request_sig
         ));
@@ -630,6 +645,7 @@ fn claim_file_ownership_works() {
         assert_ok!(URAuth::claim_ownership(
             RuntimeOrigin::signed(Alice.to_account_id()),
             ClaimType::File,
+            URIRequestType::Any { maybe_parent_acc: Alice.to_account_id() },
             "urauth://file".into(),
             owner_did,
             MultiSigner::Sr25519(Alice.public()),
@@ -663,6 +679,7 @@ fn register_dataset_works() {
                 name: "".into(),
                 description: "".into()
             },
+            URIRequestType::Any { maybe_parent_acc: Alice.to_account_id() },
             "urauth://file".into(),
             owner_did,
             MultiSigner::Sr25519(Alice.public()),
@@ -731,7 +748,7 @@ fn is_root_domain(uri: &str, claim_type: ClaimType) -> bool {
     let uri: String = uri.into();
     let raw_uri: Vec<u8> = uri.clone().into();
     let part = <URAuthParser<Test> as Parser<Test>>::parse(&raw_uri, &claim_type).unwrap();
-    <URAuthParser<Test> as Parser<Test>>::is_root(&part)
+    <URAuthParser<Test> as Parser<Test>>::is_root(&part).is_ok()
 }
 
 #[test]

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -51,43 +51,45 @@ fn request_register_ownership_works() {
         // Different DID owner with signature should fail
         assert_noop!(
             request_call
-            .clone()
-            .set_owner_did(urauth_helper.generate_did(BOB_SS58).as_bytes().to_vec())
-            .runtime_call(),
+                .clone()
+                .set_owner_did(urauth_helper.generate_did(BOB_SS58).as_bytes().to_vec())
+                .runtime_call(),
             Error::<Test>::BadSigner
         );
 
         // Different URI with signature should fail
         assert_noop!(
             request_call
-            .clone()
-            .set_sig(urauth_helper.create_signature(
-                Alice,
-                ProofType::Request(
-                    urauth_helper.bounded_uri(Some("www.website.com".into())),
-                    urauth_helper.raw_owner_did(),
-                ),
-            ))
-            .runtime_call(),
+                .clone()
+                .set_sig(urauth_helper.create_signature(
+                    Alice,
+                    ProofType::Request(
+                        urauth_helper.bounded_uri(Some("www.website.com".into())),
+                        urauth_helper.raw_owner_did(),
+                    ),
+                ))
+                .runtime_call(),
             Error::<Test>::BadProof
         );
 
         // Sign with different DID should fail
         assert_noop!(
             request_call
-            .set_sig(urauth_helper.create_signature(
-                Bob,
-                ProofType::Request(
-                    bounded_uri.clone(),
-                    urauth_helper
-                        .generate_did(BOB_SS58)
-                        .as_bytes()
-                        .to_vec()
-                        .try_into()
-                        .expect("Too long"),
-                ),
-            ))
-            .runtime_call(),
+                .set_sig(
+                    urauth_helper.create_signature(
+                        Bob,
+                        ProofType::Request(
+                            bounded_uri.clone(),
+                            urauth_helper
+                                .generate_did(BOB_SS58)
+                                .as_bytes()
+                                .to_vec()
+                                .try_into()
+                                .expect("Too long"),
+                        ),
+                    )
+                )
+                .runtime_call(),
             Error::<Test>::BadProof
         );
     });
@@ -626,90 +628,115 @@ fn integrity_test() {
         let urauth_doc = URAuthTree::<Test>::get(&reigstered_uri).unwrap();
         debug_doc(&urauth_doc);
         let uri = "sub2.sub1.website1.com".as_bytes().to_vec();
-        
-        // Parent should be Alice 
+
+        // Parent should be Alice
         assert_noop!(
             request_call
-            .clone()
-            .set_challenge(None)
-            .set_uri(uri.clone())
-            .set_request_type(URIRequestType::Any { maybe_parent_acc: Bob.to_account_id() })
-            .runtime_call(),
+                .clone()
+                .set_challenge(None)
+                .set_uri(uri.clone())
+                .set_request_type(URIRequestType::Any {
+                    maybe_parent_acc: Bob.to_account_id()
+                })
+                .runtime_call(),
             Error::<Test>::NotURAuthDocOwner
         );
 
         let bob_did = urauth_helper.generate_did(BOB_SS58).as_bytes().to_vec();
 
-        assert_ok!(
-            request_call
+        assert_ok!(request_call
             .clone()
             .set_challenge(None)
             .set_uri(uri.clone())
             .set_signer(Bob.into())
             .set_owner_did(bob_did.clone())
-            .set_request_type(URIRequestType::Any { maybe_parent_acc: Alice.to_account_id() })
-            .set_sig(urauth_helper.create_signature(Bob, ProofType::Request(uri.clone().try_into().unwrap(), bob_did.clone().try_into().unwrap())))
-            .runtime_call()
-        );
+            .set_request_type(URIRequestType::Any {
+                maybe_parent_acc: Alice.to_account_id()
+            })
+            .set_sig(urauth_helper.create_signature(
+                Bob,
+                ProofType::Request(
+                    uri.clone().try_into().unwrap(),
+                    bob_did.clone().try_into().unwrap()
+                )
+            ))
+            .runtime_call());
         let reigstered_uri: URI = uri.try_into().unwrap();
         let urauth_doc = URAuthTree::<Test>::get(&reigstered_uri).unwrap();
-        debug_doc(&urauth_doc); 
+        debug_doc(&urauth_doc);
 
         let uri = "website2.com/user".as_bytes().to_vec();
         // Request URI not in URIByOracle should be fail
         assert_noop!(
             request_call
-            .clone()
-            .set_request_type(URIRequestType::Oracle { is_root: false })
-            .set_uri(uri.clone())
-            .set_owner_did(bob_did.clone())
-            .set_sig(urauth_helper.create_signature(Bob, ProofType::Request(uri.clone().try_into().unwrap(), bob_did.clone().try_into().unwrap())))
-            .runtime_call(),
+                .clone()
+                .set_request_type(URIRequestType::Oracle { is_root: false })
+                .set_uri(uri.clone())
+                .set_owner_did(bob_did.clone())
+                .set_sig(urauth_helper.create_signature(
+                    Bob,
+                    ProofType::Request(
+                        uri.clone().try_into().unwrap(),
+                        bob_did.clone().try_into().unwrap()
+                    )
+                ))
+                .runtime_call(),
             Error::<Test>::BadClaim
         );
         assert_ok!(URAuth::add_uri_by_oracle(
             RuntimeOrigin::root(),
-            ClaimType::WebServiceAccount, 
-            URIRequestType::Oracle { is_root: false }, 
+            ClaimType::WebServiceAccount,
+            URIRequestType::Oracle { is_root: false },
             "website2.com/*".into()
         ));
-        assert_ok!(
-            request_call
+        assert_ok!(request_call
             .clone()
             .set_request_type(URIRequestType::Oracle { is_root: false })
             .set_uri(uri.clone())
             .set_owner_did(bob_did.clone())
             .set_signer(Bob.into())
-            .set_sig(urauth_helper.create_signature(Bob, ProofType::Request(uri.try_into().unwrap(), bob_did.clone().try_into().unwrap())))
-            .runtime_call()
-        );
+            .set_sig(urauth_helper.create_signature(
+                Bob,
+                ProofType::Request(uri.try_into().unwrap(), bob_did.clone().try_into().unwrap())
+            ))
+            .runtime_call());
         let uri = "website3.com/user".as_bytes().to_vec();
         let uri2 = "website3.com/feed/1/2/3".as_bytes().to_vec();
         assert_ok!(URAuth::add_uri_by_oracle(
             RuntimeOrigin::root(),
-            ClaimType::WebServiceAccount, 
-            URIRequestType::Oracle { is_root: false }, 
+            ClaimType::WebServiceAccount,
+            URIRequestType::Oracle { is_root: false },
             "website3.com/feed/*".into()
         ));
         assert_noop!(
             request_call
-            .clone()
-            .set_request_type(URIRequestType::Oracle { is_root: false })
-            .set_uri(uri.clone())
-            .set_owner_did(bob_did.clone())
-            .set_sig(urauth_helper.create_signature(Bob, ProofType::Request(uri.clone().try_into().unwrap(), bob_did.clone().try_into().unwrap())))
-            .runtime_call(),
+                .clone()
+                .set_request_type(URIRequestType::Oracle { is_root: false })
+                .set_uri(uri.clone())
+                .set_owner_did(bob_did.clone())
+                .set_sig(urauth_helper.create_signature(
+                    Bob,
+                    ProofType::Request(
+                        uri.clone().try_into().unwrap(),
+                        bob_did.clone().try_into().unwrap()
+                    )
+                ))
+                .runtime_call(),
             Error::<Test>::BadClaim
         );
-        assert_ok!(
-            request_call
+        assert_ok!(request_call
             .clone()
             .set_request_type(URIRequestType::Oracle { is_root: false })
             .set_uri(uri2.clone())
             .set_owner_did(bob_did.clone())
             .set_signer(Bob.into())
-            .set_sig(urauth_helper.create_signature(Bob, ProofType::Request(uri2.try_into().unwrap(), bob_did.clone().try_into().unwrap())))
-            .runtime_call()
-        );
+            .set_sig(urauth_helper.create_signature(
+                Bob,
+                ProofType::Request(
+                    uri2.try_into().unwrap(),
+                    bob_did.clone().try_into().unwrap()
+                )
+            ))
+            .runtime_call());
     })
 }

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -63,7 +63,7 @@ fn request_register_ownership_works() {
                 .set_sig(urauth_helper.create_signature(
                     Alice,
                     ProofType::Request(
-                        urauth_helper.bounded_uri(Some("www.website.com".into())),
+                        urauth_helper.bounded_uri(Some("https://www.website.com".into())),
                         urauth_helper.raw_owner_did(),
                         1
                     ),
@@ -542,7 +542,7 @@ fn integrity_test() {
         assert_noop!(
             request_call
                 .clone()
-                .set_uri("sub1.website1.com".as_bytes().to_vec())
+                .set_uri("https://sub1.website1.com".as_bytes().to_vec())
                 .runtime_call(),
             Error::<Test>::NotURIByOracle
         );
@@ -554,7 +554,7 @@ fn integrity_test() {
         let reigstered_uri: URI = "website1.com".as_bytes().to_vec().try_into().unwrap();
         let urauth_doc = URAuthTree::<Test>::get(&reigstered_uri).unwrap();
         debug_doc(&urauth_doc);
-        let uri = "sub2.sub1.website1.com".as_bytes().to_vec();
+        let uri = "https://sub2.sub1.website1.com".as_bytes().to_vec();
         // Registered URI should not be requested.
         assert_noop!(
             request_call.clone().runtime_call(),
@@ -592,7 +592,7 @@ fn integrity_test() {
         let urauth_doc = URAuthTree::<Test>::get(&reigstered_uri).unwrap();
         debug_doc(&urauth_doc);
 
-        let uri = "website2.com/user".as_bytes().to_vec();
+        let uri = "https://website2.com/user".as_bytes().to_vec();
         // Request URI not in URIByOracle should be fail
         assert_noop!(
             request_call
@@ -613,7 +613,7 @@ fn integrity_test() {
         assert_ok!(URAuth::add_uri_by_oracle(
             RuntimeOrigin::root(),
             ClaimType::Domain,
-            "website2.com/*".into()
+            "https://website2.com/*".into()
         ));
         assert_ok!(request_call
             .clone()
@@ -629,13 +629,13 @@ fn integrity_test() {
                 )
             ))
             .runtime_call());
-        let uri = "website3.com/user".as_bytes().to_vec();
-        let uri2 = "website3.com/feed/1/2/3".as_bytes().to_vec();
+        let uri = "https://website3.com/user".as_bytes().to_vec();
+        let uri2 = "https://website3.com/feed/1/2/3".as_bytes().to_vec();
         let parent = Bob;
         assert_ok!(URAuth::add_uri_by_oracle(
             RuntimeOrigin::root(),
             ClaimType::Domain,
-            "website3.com/feed/*".into()
+            "https://website3.com/feed/*".into()
         ));
         assert_noop!(
             request_call
@@ -727,7 +727,7 @@ fn integrity_test() {
                 )
             ))
             .runtime_call());
-        let uri = "website8.com".as_bytes().to_vec();
+        let uri = "https://website8.com".as_bytes().to_vec();
         let bounded_uri: URI = uri.clone().try_into().unwrap();
         assert_ok!(request_call
             .clone()

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -756,5 +756,17 @@ fn integrity_test() {
                 )
             ))
             .runtime_call());
+        let uri = "website4.com".as_bytes().to_vec();
+        let bounded_uri: URI = uri.clone().try_into().unwrap();
+        assert_ok!(request_call
+            .clone()
+            .set_uri(uri.clone())
+            .set_sig(urauth_helper.create_signature(Alice, ProofType::Request(bounded_uri.clone(), owner_did.try_into().unwrap())))
+            .runtime_call()
+        );
+        run_to_block(5);
+        assert!(Metadata::<Test>::get(&bounded_uri).is_none());
+        assert!(URIVerificationInfo::<Test>::get(&bounded_uri).is_none());
+        assert!(ChallengeValue::<Test>::get(&bounded_uri).is_none());
     })
 }

--- a/pallets/urauth/src/tests.rs
+++ b/pallets/urauth/src/tests.rs
@@ -193,7 +193,7 @@ fn update_urauth_doc_works() {
             RuntimeOrigin::signed(Alice.to_account_id()),
             challenge_value
         ));
-        
+
         let register_uri: URI = "website1.com".as_bytes().to_vec().try_into().unwrap();
         let mut urauth_doc = URAuthTree::<Test>::get(&register_uri).unwrap();
         debug_doc(&urauth_doc);
@@ -564,8 +564,11 @@ fn integrity_test() {
         debug_doc(&urauth_doc);
         let uri = "sub2.sub1.website1.com".as_bytes().to_vec();
         // Registered URI should not be requested.
-        assert_noop!(request_call.clone().runtime_call(), Error::<Test>::AlreadyRegistered);
-        
+        assert_noop!(
+            request_call.clone().runtime_call(),
+            Error::<Test>::AlreadyRegistered
+        );
+
         // Parent should be Alice
         assert_noop!(
             request_call
@@ -682,64 +685,76 @@ fn integrity_test() {
             .clone()
             .set_challenge(None)
             .set_claim_type(ClaimType::File)
-            .set_request_type(URIRequestType::Any { is_root: true, maybe_parent_acc: None })
+            .set_request_type(URIRequestType::Any {
+                is_root: true,
+                maybe_parent_acc: None
+            })
             .set_uri(uri.clone())
             .set_sig(urauth_helper.create_signature(
-                Alice, 
+                Alice,
                 ProofType::Request(
-                    uri.try_into().unwrap(), 
+                    uri.try_into().unwrap(),
                     owner_did.clone().try_into().unwrap()
                 )
             ))
-            .runtime_call()
-        );
+            .runtime_call());
         let uri = "urauth://file/cid/1".as_bytes().to_vec();
-        assert_noop!(request_call
-            .clone()
-            .set_challenge(None)
-            .set_claim_type(ClaimType::File)
-            .set_request_type(URIRequestType::Any { is_root: true, maybe_parent_acc: None })
-            .set_uri(uri.clone())
-            .set_sig(urauth_helper.create_signature(
-                Alice, 
-                ProofType::Request(
-                    uri.clone().try_into().unwrap(), 
-                    owner_did.clone().try_into().unwrap()
-                )
-            ))
-            .runtime_call(),
+        assert_noop!(
+            request_call
+                .clone()
+                .set_challenge(None)
+                .set_claim_type(ClaimType::File)
+                .set_request_type(URIRequestType::Any {
+                    is_root: true,
+                    maybe_parent_acc: None
+                })
+                .set_uri(uri.clone())
+                .set_sig(urauth_helper.create_signature(
+                    Alice,
+                    ProofType::Request(
+                        uri.clone().try_into().unwrap(),
+                        owner_did.clone().try_into().unwrap()
+                    )
+                ))
+                .runtime_call(),
             Error::<Test>::NotRootURI
         );
-        assert_noop!(request_call
-            .clone()
-            .set_challenge(None)
-            .set_claim_type(ClaimType::File)
-            .set_request_type(URIRequestType::Any { is_root: false, maybe_parent_acc: Some(Bob.to_account_id()) })
-            .set_uri(uri.clone())
-            .set_sig(urauth_helper.create_signature(
-                Alice, 
-                ProofType::Request(
-                    uri.clone().try_into().unwrap(), 
-                    owner_did.clone().try_into().unwrap()
-                )
-            ))
-            .runtime_call(),
+        assert_noop!(
+            request_call
+                .clone()
+                .set_challenge(None)
+                .set_claim_type(ClaimType::File)
+                .set_request_type(URIRequestType::Any {
+                    is_root: false,
+                    maybe_parent_acc: Some(Bob.to_account_id())
+                })
+                .set_uri(uri.clone())
+                .set_sig(urauth_helper.create_signature(
+                    Alice,
+                    ProofType::Request(
+                        uri.clone().try_into().unwrap(),
+                        owner_did.clone().try_into().unwrap()
+                    )
+                ))
+                .runtime_call(),
             Error::<Test>::NotURAuthDocOwner
         );
         assert_ok!(request_call
             .clone()
             .set_challenge(None)
             .set_claim_type(ClaimType::File)
-            .set_request_type(URIRequestType::Any { is_root: false, maybe_parent_acc: Some(Alice.to_account_id()) })
+            .set_request_type(URIRequestType::Any {
+                is_root: false,
+                maybe_parent_acc: Some(Alice.to_account_id())
+            })
             .set_uri(uri.clone())
             .set_sig(urauth_helper.create_signature(
-                Alice, 
+                Alice,
                 ProofType::Request(
-                    uri.try_into().unwrap(), 
+                    uri.try_into().unwrap(),
                     owner_did.clone().try_into().unwrap()
                 )
             ))
-            .runtime_call()
-        );
+            .runtime_call());
     })
 }

--- a/pallets/urauth/src/types.rs
+++ b/pallets/urauth/src/types.rs
@@ -21,28 +21,6 @@ pub type URIPartFor<T> = <<T as Config>::URAuthParser as Parser<T>>::Part;
 pub type ClaimTypeFor<T> = <<T as Config>::URAuthParser as Parser<T>>::ClaimType;
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
-pub struct URIType {
-    pub is_root: bool,
-    pub is_oracle: bool,
-    pub claim_type: ClaimType,
-}
-
-impl URIType {
-
-    pub fn new(is_root: bool, is_oracle: bool, claim_type: ClaimType) -> Self {
-        Self {
-            is_root,
-            is_oracle,
-            claim_type
-        }
-    }
-
-    pub fn is_oracle(&self) -> bool {
-        self.is_oracle
-    } 
-}
-
-#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
 pub enum ClaimType {
     Domain,
     Contents {
@@ -242,7 +220,7 @@ impl<BoundedString> DataSetMetadata<BoundedString> {
 pub struct RequestMetadata {
     pub owner_did: OwnerDID,
     pub challenge_value: Randomness,
-    pub uri_type: URIType,
+    pub claim_type: ClaimType,
     pub maybe_register_uri: URI,
 }
 
@@ -250,13 +228,13 @@ impl RequestMetadata {
     pub fn new(
         owner_did: OwnerDID,
         challenge_value: Randomness,
-        uri_type: URIType,
+        claim_type: ClaimType,
         maybe_register_uri: URI,
     ) -> Self {
         Self {
             owner_did,
             challenge_value,
-            uri_type,
+            claim_type,
             maybe_register_uri,
         }
     }

--- a/pallets/urauth/src/types.rs
+++ b/pallets/urauth/src/types.rs
@@ -216,16 +216,21 @@ pub struct RequestMetadata {
     pub owner_did: OwnerDID,
     pub challenge_value: Randomness,
     pub claim_type: ClaimType,
-    pub maybe_register_uri: URI
+    pub maybe_register_uri: URI,
 }
 
 impl RequestMetadata {
-    pub fn new(owner_did: OwnerDID, challenge_value: Randomness, claim_type: ClaimType, maybe_register_uri: URI) -> Self {
+    pub fn new(
+        owner_did: OwnerDID,
+        challenge_value: Randomness,
+        claim_type: ClaimType,
+        maybe_register_uri: URI,
+    ) -> Self {
         Self {
             owner_did,
             challenge_value,
             claim_type,
-            maybe_register_uri
+            maybe_register_uri,
         }
     }
 }

--- a/pallets/urauth/src/types.rs
+++ b/pallets/urauth/src/types.rs
@@ -701,6 +701,32 @@ impl sp_runtime::traits::Printable for UpdateDocStatusError {
     }
 }
 
+pub trait Parser<T: Config> {
+
+    type ChallengeValue: Default;
+
+    fn url(raw_url: &Vec<u8>) -> Result<(), DispatchError>;
+
+    fn challenge_json() -> Result<Self::ChallengeValue, DispatchError> {
+        Ok(Default::default())
+    }
+}
+
+pub struct URAuthParser;
+impl<T: Config> Parser<T> for URAuthParser {
+
+    type ChallengeValue = Vec<u8>;
+
+    fn url(raw_url: &Vec<u8>) -> Result<(), DispatchError> {
+        let url = sp_std::str::from_utf8(&raw_url[..])
+            .map_err(|_| Error::<T>::ErrorConvertToString)?;
+        let url = ada_url::Url::parse(url, None)
+            .map_err(|_| Error::<T>::ErrorOnParse)?;
+
+        Ok(())
+    }
+}
+
 pub mod max_size {
 
     use super::*;

--- a/pallets/urauth/src/types.rs
+++ b/pallets/urauth/src/types.rs
@@ -436,7 +436,7 @@ where
             + u128::max_encoded_len()
             + MultiDID::<Account>::max_encoded_len()
             + IdentityInfo::max_encoded_len() * MAX_MULTI_OWNERS_NUM
-            + AccessRule::max_encoded_len()
+            + AccessRule::max_encoded_len() * MAX_ACCESS_RULES
             + CopyrightInfo::max_encoded_len()
             + ContentMetadata::max_encoded_len()
             + Proof::max_encoded_len() * MAX_MULTI_OWNERS_NUM
@@ -542,6 +542,15 @@ pub enum UpdateDocField<Account> {
     AccessRules(Option<Vec<AccessRule>>),
 }
 
+impl<Account> MaxEncodedLen for UpdateDocField<Account> 
+where 
+    Account: Encode
+{
+    fn max_encoded_len() -> usize {
+        AccessRule::max_encoded_len() * MAX_ACCESS_RULES
+    }
+}
+
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
 pub enum UpdateStatus<Account> {
     /// Hold updated field and its proofs. Proofs will be stored on `URAuthDoc`
@@ -552,8 +561,18 @@ pub enum UpdateStatus<Account> {
     Available,
 }
 
+impl<Account> MaxEncodedLen for UpdateStatus<Account> 
+where
+    Account: Encode
+{
+    fn max_encoded_len() -> usize {
+        UpdateDocField::<Account>::max_encoded_len()
+            + Proof::max_encoded_len() * MAX_MULTI_OWNERS_NUM
+    }
+}
+
 /// Status for updating `URAuthDoc`
-#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub struct UpdateDocStatus<Account> {
     /// Threshold for updating
     pub remaining_threshold: DIDWeight,
@@ -690,7 +709,7 @@ pub mod max_size {
 
     /// Maximum number of `access_rules` we expect in a single `MultiDID` value. Note this is not (yet)
     /// enforced, and just serves to provide a sensible `max_encoded_len` for `MultiDID`.
-    pub const MAX_ACCESS_RULES: u32 = 10;
+    pub const MAX_ACCESS_RULES: usize = 100;
 
     /// Maximum number of `user agents` we expect in a single `MultiDID` value. Note this is not (yet)
     /// enforced, and just serves to provide a sensible `max_encoded_len` for `MultiDID`.

--- a/pallets/urauth/src/types.rs
+++ b/pallets/urauth/src/types.rs
@@ -22,8 +22,13 @@ pub type ClaimTypeFor<T> = <<T as Config>::URAuthParser as Parser<T>>::ClaimType
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub enum URIRequestType<Account> {
-    Oracle { is_root: bool },
-    Any { is_root: bool, maybe_parent_acc: Option<Account> },
+    Oracle {
+        is_root: bool,
+    },
+    Any {
+        is_root: bool,
+        maybe_parent_acc: Option<Account>,
+    },
 }
 
 #[derive(Encode, Decode, Clone, Eq, RuntimeDebug, TypeInfo)]
@@ -149,8 +154,8 @@ impl URIPart {
         let mut is_root: bool = false;
         // Root of 'File' and 'Dataset' has CID
         // e.g urauth://file/{cid}
-        if matches!(claim_type, ClaimType::File) || 
-        matches!(claim_type, ClaimType::Dataset { .. }) {
+        if matches!(claim_type, ClaimType::File) || matches!(claim_type, ClaimType::Dataset { .. })
+        {
             let mut count = 0;
             let slash = b'/';
             if let Some(path) = self.path.clone() {
@@ -910,7 +915,6 @@ pub trait Parser<T: Config> {
 
 pub struct URAuthParser<T>(PhantomData<T>);
 impl<T: Config> URAuthParser<T> {
-
     /// Find the start index of where sub-domain is started.
     /// ### Example
     /// 1. file -> None
@@ -922,8 +926,9 @@ impl<T: Config> URAuthParser<T> {
         let mut maybe_index: Option<usize> = None;
         while let Some(i) = temp.rfind('.') {
             count += 1;
-            if matches!(claim_type, ClaimType::File) || 
-            matches!(claim_type, ClaimType::Dataset { .. }) {
+            if matches!(claim_type, ClaimType::File)
+                || matches!(claim_type, ClaimType::Dataset { .. })
+            {
                 maybe_index = Some(i);
                 break;
             }
@@ -932,7 +937,7 @@ impl<T: Config> URAuthParser<T> {
                 break;
             }
             temp = &temp[0..i];
-        };
+        }
         maybe_index
     }
 
@@ -986,9 +991,11 @@ impl<T: Config> URAuthParser<T> {
             if_std! { println!("{:?}", temp)}
             if let Some(i) = sub_domain_index {
                 sub_domain = Some(temp[0..=i].as_bytes().to_vec());
-                host = Some(temp[i+1..].as_bytes().to_vec())
+                host = Some(temp[i + 1..].as_bytes().to_vec())
             } else {
-                if *claim_type == ClaimType::WebsiteDomain || *claim_type == ClaimType::WebServiceAccount {
+                if *claim_type == ClaimType::WebsiteDomain
+                    || *claim_type == ClaimType::WebServiceAccount
+                {
                     sub_domain = Some("www.".as_bytes().to_vec());
                 }
                 host = Some(temp.as_bytes().to_vec())
@@ -1240,7 +1247,10 @@ mod tests {
 
         let raw_uri = "sub2.sub1.file/cid".as_bytes().to_vec();
         let uri_part = URAuthParser::<Test>::try_parse(&raw_uri, &ClaimType::File).unwrap();
-        println!("{:?}", sp_std::str::from_utf8(&uri_part.host.clone().unwrap()));
+        println!(
+            "{:?}",
+            sp_std::str::from_utf8(&uri_part.host.clone().unwrap())
+        );
         assert_eq!(uri_part.scheme, "urauth://".as_bytes().to_vec());
         assert_eq!(uri_part.host, Some("file".as_bytes().to_vec()));
         assert_eq!(uri_part.sub_domain, Some("sub2.sub1.".as_bytes().to_vec()));
@@ -1301,8 +1311,14 @@ mod tests {
         );
         assert_eq!(is_root_domain("urauth://file/", ClaimType::File), false);
         assert_eq!(is_root_domain("urauth://file/cid", ClaimType::File), true);
-        assert_eq!(is_root_domain("urauth://file/cid/1", ClaimType::File), false);
-        assert_eq!(is_root_domain("urauth://sub1.file/cid/1", ClaimType::File), false);
+        assert_eq!(
+            is_root_domain("urauth://file/cid/1", ClaimType::File),
+            false
+        );
+        assert_eq!(
+            is_root_domain("urauth://sub1.file/cid/1", ClaimType::File),
+            false
+        );
     }
 
     fn is_root_domain(uri: &str, claim_type: ClaimType) -> bool {

--- a/pallets/urauth/src/types.rs
+++ b/pallets/urauth/src/types.rs
@@ -18,6 +18,8 @@ pub type URAuthDocCount = u128;
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
 pub enum ClaimType {
+    WebsiteDomain,
+    WebServiceAccount,
     File,
     Dataset {
         data_source: Option<Vec<u8>>,

--- a/pallets/urauth/src/types.rs
+++ b/pallets/urauth/src/types.rs
@@ -935,7 +935,9 @@ pub trait Parser<T: Config> {
         claim_type: &ClaimType,
     ) -> Result<Vec<URI>, DispatchError>;
 
-    fn parse_challenge_json(challenge_json: &Vec<u8>) -> Result<Self::ChallengeValue, DispatchError>;
+    fn parse_challenge_json(
+        challenge_json: &Vec<u8>,
+    ) -> Result<Self::ChallengeValue, DispatchError>;
 }
 
 pub struct URAuthParser<T>(PhantomData<T>);
@@ -1117,7 +1119,10 @@ impl<T: Config> Parser<T> for URAuthParser<T> {
     type ClaimType = ClaimType;
     type ChallengeValue = (Vec<u8>, Vec<u8>, Vec<u8>, URI, OwnerDID, Vec<u8>);
 
-    fn parse_uri(raw_uri: &Vec<u8>, claim_type: &Self::ClaimType) -> Result<Self::Part, DispatchError> {
+    fn parse_uri(
+        raw_uri: &Vec<u8>,
+        claim_type: &Self::ClaimType,
+    ) -> Result<Self::Part, DispatchError> {
         Self::try_parse(raw_uri, claim_type)
     }
 
@@ -1128,9 +1133,11 @@ impl<T: Config> Parser<T> for URAuthParser<T> {
         Self::try_parse_parent_uris(raw_uri, claim_type)
     }
 
-    fn parse_challenge_json(challenge_json: &Vec<u8>) -> Result<Self::ChallengeValue, DispatchError> {
-        let json_str = sp_std::str::from_utf8(challenge_json)
-            .map_err(|_| Error::<T>::ErrorConvertToString)?;
+    fn parse_challenge_json(
+        challenge_json: &Vec<u8>,
+    ) -> Result<Self::ChallengeValue, DispatchError> {
+        let json_str =
+            sp_std::str::from_utf8(challenge_json).map_err(|_| Error::<T>::ErrorConvertToString)?;
 
         return match lite_json::parse_json(json_str) {
             Ok(obj) => match obj {

--- a/pallets/urauth/src/types.rs
+++ b/pallets/urauth/src/types.rs
@@ -123,7 +123,9 @@ impl URIPart {
             .clone()
             .map_or("".as_bytes().to_vec(), |v| v);
         let mut path = self.path.clone().map_or("".as_bytes().to_vec(), |v| v);
-        full.append(&mut sub_domain);
+        if sub_domain != "www.".as_bytes().to_vec() {
+            full.append(&mut sub_domain);
+        }
         full.append(&mut host);
         full.append(&mut path);
         (maybe_scheme, full)
@@ -214,14 +216,16 @@ pub struct RequestMetadata {
     pub owner_did: OwnerDID,
     pub challenge_value: Randomness,
     pub claim_type: ClaimType,
+    pub maybe_register_uri: URI
 }
 
 impl RequestMetadata {
-    pub fn new(owner_did: OwnerDID, challenge_value: Randomness, claim_type: ClaimType) -> Self {
+    pub fn new(owner_did: OwnerDID, challenge_value: Randomness, claim_type: ClaimType, maybe_register_uri: URI) -> Self {
         Self {
             owner_did,
             challenge_value,
             claim_type,
+            maybe_register_uri
         }
     }
 }

--- a/pallets/urauth/src/types.rs
+++ b/pallets/urauth/src/types.rs
@@ -1,9 +1,8 @@
-
 use super::*;
 
 use codec::{Decode, Encode, MaxEncodedLen};
-pub use size::*;
 use scale_info::TypeInfo;
+pub use size::*;
 use sp_runtime::RuntimeDebug;
 use sp_std::{collections::btree_map::BTreeMap, if_std};
 
@@ -46,13 +45,13 @@ impl PartialEq for URIPart {
         match (self.sub_domain.clone(), other.sub_domain.clone()) {
             (Some(s), Some(o_s)) => {
                 if s.len() < o_s.len() {
-                    return false
+                    return false;
                 }
                 if let Some(i) = o_s.iter().position(|s| *s == any) {
-                    if i+1 > o_s.len() {
+                    if i + 1 > o_s.len() {
                         return false;
                     }
-                    if s[i+1..o_s.len()].to_vec() != o_s[i+1..o_s.len()].to_vec() {
+                    if s[i + 1..o_s.len()].to_vec() != o_s[i + 1..o_s.len()].to_vec() {
                         return false;
                     }
                 } else {
@@ -60,23 +59,23 @@ impl PartialEq for URIPart {
                         return false;
                     }
                 }
-            },
-            (None, None) => {},
-            _ => { return false }
+            }
+            (None, None) => {}
+            _ => return false,
         }
         match (self.host.clone(), other.host.clone()) {
             (Some(s), Some(o_s)) => {
                 if s != o_s {
-                    return false
+                    return false;
                 }
-            },
-            (None, None) => {},
-            _ => { return false }
+            }
+            (None, None) => {}
+            _ => return false,
         }
         match (self.path.clone(), other.path.clone()) {
             (Some(s), Some(o_s)) => {
                 if s.len() < o_s.len() {
-                    return false
+                    return false;
                 }
                 if let Some(i) = o_s.iter().position(|s| *s == any) {
                     if s[0..i].to_vec() != o_s[0..i].to_vec() {
@@ -87,9 +86,9 @@ impl PartialEq for URIPart {
                         return false;
                     }
                 }
-            },
-            (None, None) => {},
-            _ => { return false }
+            }
+            (None, None) => {}
+            _ => return false,
         }
         true
     }
@@ -97,9 +96,9 @@ impl PartialEq for URIPart {
 
 impl URIPart {
     pub fn new(
-        scheme: Vec<u8>, 
-        sub_domain: Option<Vec<u8>>, 
-        host: Option<Vec<u8>>, 
+        scheme: Vec<u8>,
+        sub_domain: Option<Vec<u8>>,
+        host: Option<Vec<u8>>,
         path: Option<Vec<u8>>,
     ) -> Self {
         Self {
@@ -114,14 +113,15 @@ impl URIPart {
         let mut full = Vec::new();
         let mut scheme = self.scheme.clone();
         let mut maybe_scheme: Option<Vec<u8>> = None;
-        if scheme != "https://".as_bytes().to_vec() 
-            && scheme != "https://".as_bytes().to_vec() 
-        {
+        if scheme != "https://".as_bytes().to_vec() && scheme != "https://".as_bytes().to_vec() {
             full.append(&mut scheme);
             maybe_scheme = Some(scheme);
         }
         let mut host = self.host.clone().map_or("".as_bytes().to_vec(), |v| v);
-        let mut sub_domain = self.sub_domain.clone().map_or("".as_bytes().to_vec(), |v| v);
+        let mut sub_domain = self
+            .sub_domain
+            .clone()
+            .map_or("".as_bytes().to_vec(), |v| v);
         let mut path = self.path.clone().map_or("".as_bytes().to_vec(), |v| v);
         full.append(&mut sub_domain);
         full.append(&mut host);
@@ -133,8 +133,7 @@ impl URIPart {
         let mut root: Vec<u8> = Vec::new();
         let mut scheme = self.scheme.clone();
         if let Some(mut host) = self.host.clone() {
-            if scheme != "http://".as_bytes().to_vec() 
-                && scheme != "https://".as_bytes().to_vec() {
+            if scheme != "http://".as_bytes().to_vec() && scheme != "https://".as_bytes().to_vec() {
                 root.append(&mut scheme);
             }
             root.append(&mut host);
@@ -151,7 +150,7 @@ impl URIPart {
                 if sub_domain == "www.".as_bytes().to_vec() && self.path == None {
                     is_root = true;
                 }
-            },
+            }
             None => {
                 if self.path == None {
                     is_root = true;
@@ -169,8 +168,8 @@ impl std::fmt::Display for URIPart {
         let sub_domain = self.sub_domain.clone().map_or(Vec::new(), |s| s);
         let path = self.path.clone().map_or(Vec::new(), |s| s);
         write!(
-            f, 
-            "Scheme => {:?}, Sub => {:?}, Host => {:?}, Path => {:?}", 
+            f,
+            "Scheme => {:?}, Sub => {:?}, Host => {:?}, Path => {:?}",
             std::str::from_utf8(&self.scheme).unwrap(),
             std::str::from_utf8(&sub_domain).unwrap(),
             std::str::from_utf8(&host).unwrap(),
@@ -214,19 +213,15 @@ impl<BoundedString> DataSetMetadata<BoundedString> {
 pub struct RequestMetadata {
     pub owner_did: OwnerDID,
     pub challenge_value: Randomness,
-    pub claim_type: ClaimType
+    pub claim_type: ClaimType,
 }
 
 impl RequestMetadata {
-    pub fn new(
-        owner_did: OwnerDID, 
-        challenge_value: Randomness,
-        claim_type: ClaimType,
-    ) -> Self {
+    pub fn new(owner_did: OwnerDID, challenge_value: Randomness, claim_type: ClaimType) -> Self {
         Self {
             owner_did,
             challenge_value,
-            claim_type
+            claim_type,
         }
     }
 }
@@ -641,7 +636,7 @@ where
             data_source,
         }
     }
-    
+
     pub fn is_owner(&self, who: &Account) -> bool {
         self.multi_owner_did.is_owner(who)
     }
@@ -717,9 +712,9 @@ pub enum UpdateDocField<Account> {
     AccessRules(Option<Vec<AccessRule>>),
 }
 
-impl<Account> MaxEncodedLen for UpdateDocField<Account> 
-where 
-    Account: Encode
+impl<Account> MaxEncodedLen for UpdateDocField<Account>
+where
+    Account: Encode,
 {
     fn max_encoded_len() -> usize {
         AccessRule::max_encoded_len() * MAX_ACCESS_RULES
@@ -736,9 +731,9 @@ pub enum UpdateStatus<Account> {
     Available,
 }
 
-impl<Account> MaxEncodedLen for UpdateStatus<Account> 
+impl<Account> MaxEncodedLen for UpdateStatus<Account>
 where
-    Account: Encode
+    Account: Encode,
 {
     fn max_encoded_len() -> usize {
         UpdateDocField::<Account>::max_encoded_len()
@@ -875,15 +870,17 @@ impl sp_runtime::traits::Printable for UpdateDocStatusError {
 }
 
 pub trait Parser<T: Config> {
-
-    type URI; 
+    type URI;
     type Part: Clone + sp_std::fmt::Debug + PartialEq;
     type ClaimType;
     type ChallengeValue: Default;
 
     fn parse(raw_uri: &Vec<u8>, claim_type: &ClaimType) -> Result<Self::Part, DispatchError>;
 
-    fn parse_parent_uris(raw_uri: &Vec<u8>, claim_type: &ClaimType) -> Result<Vec<URI>, DispatchError>;
+    fn parse_parent_uris(
+        raw_uri: &Vec<u8>,
+        claim_type: &ClaimType,
+    ) -> Result<Vec<URI>, DispatchError>;
 
     fn challenge_json() -> Result<Self::ChallengeValue, DispatchError> {
         Ok(Default::default())
@@ -891,13 +888,13 @@ pub trait Parser<T: Config> {
 }
 
 pub struct URAuthParser<T>(PhantomData<T>);
-impl<T: Config> URAuthParser<T> {   
-
+impl<T: Config> URAuthParser<T> {
     fn add_protocol_if_none(raw_uri: Vec<u8>, claim_type: &ClaimType) -> Vec<u8> {
         let mut uri: Vec<u8> = Vec::new();
         let mut raw_uri_bytes = raw_uri;
         let mut protocol_bytes = "https://".as_bytes().to_vec();
-        if matches!(claim_type, ClaimType::Dataset { .. }) || matches!(claim_type, ClaimType::File) {
+        if matches!(claim_type, ClaimType::Dataset { .. }) || matches!(claim_type, ClaimType::File)
+        {
             protocol_bytes = "urauth://".as_bytes().to_vec();
         }
         let mut is_protocol_exist: bool = false;
@@ -937,25 +934,31 @@ impl<T: Config> URAuthParser<T> {
         }
         let mut host: Option<Vec<u8>> = None;
         if url.has_hostname() {
-            let domain = addr::parse_domain_name(url.hostname())
-                .map_err(|_| Error::<T>::ErrorOnParse)?;
+            let domain =
+                addr::parse_domain_name(url.hostname()).map_err(|_| Error::<T>::ErrorOnParse)?;
             if domain.root() == None {
-                let temp_host = url.hostname().as_bytes().to_vec(); 
+                let temp_host = url.hostname().as_bytes().to_vec();
                 let host_str = sp_std::str::from_utf8(&temp_host)
                     .map_err(|_| Error::<T>::ErrorConvertToString)?;
                 if let Some(i) = host_str.clone().rfind('.') {
-                    sub_domain = Some(host_str[0..i+1].as_bytes().to_vec());
+                    sub_domain = Some(host_str[0..i + 1].as_bytes().to_vec());
                 }
                 host = Some(temp_host);
             } else {
                 if domain.prefix() != None {
-                    sub_domain = domain.prefix().map(|s| { 
+                    sub_domain = domain.prefix().map(|s| {
                         let mut bytes = s.as_bytes().to_vec();
-                        bytes.append(&mut ".".as_bytes().to_vec()); 
+                        bytes.append(&mut ".".as_bytes().to_vec());
                         bytes
                     });
                 }
-                host = Some(domain.root().ok_or(Error::<T>::ErrorOnParse)?.as_bytes().to_vec());
+                host = Some(
+                    domain
+                        .root()
+                        .ok_or(Error::<T>::ErrorOnParse)?
+                        .as_bytes()
+                        .to_vec(),
+                );
             }
         }
 
@@ -963,24 +966,29 @@ impl<T: Config> URAuthParser<T> {
     }
 
     /// Parse the given uri and will return the list of the parsed `URI`
-    fn try_parse_parent_uris(raw_uri: &Vec<u8>, claim_type: &ClaimType) -> Result<Vec<URI>, DispatchError> {
-        
+    fn try_parse_parent_uris(
+        raw_uri: &Vec<u8>,
+        claim_type: &ClaimType,
+    ) -> Result<Vec<URI>, DispatchError> {
         let uri_part = Self::try_parse(raw_uri, claim_type)?;
-        let mut is_root = false; 
+        let mut is_root = false;
         if uri_part.is_root() {
             is_root = true;
         }
         // Only parse if there is root. Otherwise, return `Err`
         if let Some(base) = uri_part.root() {
-            let base = sp_std::str::from_utf8(&base)
-                .map_err(|_| Error::<T>::ErrorConvertToString)?;
+            let base =
+                sp_std::str::from_utf8(&base).map_err(|_| Error::<T>::ErrorConvertToString)?;
             let (maybe_protocol, full_uri) = uri_part.full_uri();
-            let uri = sp_std::str::from_utf8(&full_uri)
-                .map_err(|_| Error::<T>::ErrorConvertToString)?;
+            let uri =
+                sp_std::str::from_utf8(&full_uri).map_err(|_| Error::<T>::ErrorConvertToString)?;
             if is_root {
-                let bounded_uri: URI = uri.as_bytes().to_vec().try_into()
+                let bounded_uri: URI = uri
+                    .as_bytes()
+                    .to_vec()
+                    .try_into()
                     .map_err(|_| Error::<T>::OverMaxSize)?;
-                return Ok(sp_std::vec![ bounded_uri ])
+                return Ok(sp_std::vec![bounded_uri]);
             }
             let mut uris: Vec<URI> = Vec::new();
             let mut parent_uri = uri.clone();
@@ -991,7 +999,11 @@ impl<T: Config> URAuthParser<T> {
                 }
                 parent_uri = &uri[0..i];
                 sp_std::if_std! { println!("{:?}", parent_uri) }
-                let bounded_uri: URI = parent_uri.as_bytes().to_vec().try_into().map_err(|_| Error::<T>::OverMaxSize)?; 
+                let bounded_uri: URI = parent_uri
+                    .as_bytes()
+                    .to_vec()
+                    .try_into()
+                    .map_err(|_| Error::<T>::OverMaxSize)?;
                 uris.push(bounded_uri);
             }
             // 2. Parse sub-domain
@@ -999,14 +1011,16 @@ impl<T: Config> URAuthParser<T> {
                 if parent_uri == base {
                     break;
                 }
-                parent_uri = &parent_uri[i+1..];
+                parent_uri = &parent_uri[i + 1..];
                 let mut parent_uri_bytes = parent_uri.as_bytes().to_vec();
                 if let Some(mut protocol) = maybe_protocol.clone() {
                     protocol.append(&mut parent_uri_bytes);
                     parent_uri_bytes = protocol;
                 }
                 sp_std::if_std! { println!("{:?}", sp_std::str::from_utf8(&parent_uri_bytes).expect("")) }
-                let bounded_uri: URI = parent_uri_bytes.try_into().map_err(|_| Error::<T>::OverMaxSize)?; 
+                let bounded_uri: URI = parent_uri_bytes
+                    .try_into()
+                    .map_err(|_| Error::<T>::OverMaxSize)?;
                 uris.push(bounded_uri);
             }
             Ok(uris)
@@ -1016,7 +1030,6 @@ impl<T: Config> URAuthParser<T> {
     }
 }
 impl<T: Config> Parser<T> for URAuthParser<T> {
-    
     type URI = URI;
     type Part = URIPart;
     type ClaimType = ClaimType;
@@ -1026,7 +1039,10 @@ impl<T: Config> Parser<T> for URAuthParser<T> {
         Self::try_parse(raw_uri, claim_type)
     }
 
-    fn parse_parent_uris(raw_uri: &Vec<u8>, claim_type: &Self::ClaimType) -> Result<Vec<Self::URI>, DispatchError> {
+    fn parse_parent_uris(
+        raw_uri: &Vec<u8>,
+        claim_type: &Self::ClaimType,
+    ) -> Result<Vec<Self::URI>, DispatchError> {
         Self::try_parse_parent_uris(raw_uri, claim_type)
     }
 }
@@ -1142,18 +1158,22 @@ mod tests {
         assert_eq!(submission.threshold, 3);
     }
 
-    // cargo t -p pallet-urauth --lib -- types::tests::deconstruct_works --exact --nocapture 
+    // cargo t -p pallet-urauth --lib -- types::tests::deconstruct_works --exact --nocapture
     #[test]
     fn parse_works() {
         // URI with length less than minimum should fail
-        assert!(URAuthParser::<Test>::try_parse(&"in".as_bytes().to_vec(), &ClaimType::WebsiteDomain).is_err());
+        assert!(URAuthParser::<Test>::try_parse(
+            &"in".as_bytes().to_vec(),
+            &ClaimType::WebsiteDomain
+        )
+        .is_err());
 
         // Full URI with domain
-        let raw_uri = "https://sub2.sub1.instagram.com/user1/feed".as_bytes().to_vec();
-        let uri_part = URAuthParser::<Test>::try_parse(
-            &raw_uri,
-            &ClaimType::WebServiceAccount
-        ).unwrap();
+        let raw_uri = "https://sub2.sub1.instagram.com/user1/feed"
+            .as_bytes()
+            .to_vec();
+        let uri_part =
+            URAuthParser::<Test>::try_parse(&raw_uri, &ClaimType::WebServiceAccount).unwrap();
         assert_eq!(uri_part.scheme, "https://".as_bytes().to_vec());
         assert_eq!(uri_part.host, Some("instagram.com".as_bytes().to_vec()));
         assert_eq!(uri_part.sub_domain, Some("sub2.sub1.".as_bytes().to_vec()));
@@ -1161,10 +1181,8 @@ mod tests {
 
         // URI without scheme. Default is 'https://'
         let raw_uri = "instagram.com/user1/feed".as_bytes().to_vec();
-        let uri_part = URAuthParser::<Test>::try_parse(
-            &raw_uri,
-            &ClaimType::WebServiceAccount
-        ).unwrap();
+        let uri_part =
+            URAuthParser::<Test>::try_parse(&raw_uri, &ClaimType::WebServiceAccount).unwrap();
         assert_eq!(uri_part.scheme, "https://".as_bytes().to_vec());
         assert_eq!(uri_part.host, Some("instagram.com".as_bytes().to_vec()));
         assert_eq!(uri_part.sub_domain, None);
@@ -1172,42 +1190,74 @@ mod tests {
 
         // Full URI related to 'file' or 'dataset'
         let raw_uri = "urauth://file/cid".as_bytes().to_vec();
-        let uri_part = URAuthParser::<Test>::try_parse(
-            &raw_uri,
-            &ClaimType::File
-        ).unwrap();
+        let uri_part = URAuthParser::<Test>::try_parse(&raw_uri, &ClaimType::File).unwrap();
         assert_eq!(uri_part.scheme, "urauth://".as_bytes().to_vec());
         assert_eq!(uri_part.host, Some("file".as_bytes().to_vec()));
         assert_eq!(uri_part.sub_domain, None);
         assert_eq!(uri_part.path, Some("/cid".as_bytes().to_vec()));
 
-        // Partial URI related to 'file' or 'dataset'. 
+        // Partial URI related to 'file' or 'dataset'.
         // Scheme will be set to 'urauth://'
         let raw_uri = "file/cid".as_bytes().to_vec();
-        let uri_part = URAuthParser::<Test>::try_parse(
-            &raw_uri,
-            &ClaimType::File
-        ).unwrap();
+        let uri_part = URAuthParser::<Test>::try_parse(&raw_uri, &ClaimType::File).unwrap();
         assert_eq!(uri_part.scheme, "urauth://".as_bytes().to_vec());
         assert_eq!(uri_part.host, Some("file".as_bytes().to_vec()));
         assert_eq!(uri_part.sub_domain, None);
         assert_eq!(uri_part.path, Some("/cid".as_bytes().to_vec()));
     }
 
-    // cargo t -p pallet-urauth --lib -- tests::parser_works --exact --nocapture 
+    // cargo t -p pallet-urauth --lib -- tests::parser_works --exact --nocapture
     #[test]
     fn parser_works() {
-
-        assert_eq!(is_root_domain("http://instagram.com", ClaimType::WebServiceAccount), true);
-        assert_eq!(is_root_domain("https://instagram.com", ClaimType::WebServiceAccount), true);
-        assert_eq!(is_root_domain("https://www.instagram.com", ClaimType::WebServiceAccount), true);
-        assert_eq!(is_root_domain("https://sub2.sub1.www.instagram.com", ClaimType::WebServiceAccount), false);
-        assert_eq!(is_root_domain("ftp://www.instagram.com", ClaimType::WebServiceAccount), true);
-        assert_eq!(is_root_domain("ftp://instagram.com", ClaimType::WebServiceAccount), true);
-        assert_eq!(is_root_domain("ftp://sub2.sub1.www.instagram.com", ClaimType::WebServiceAccount), false);
-        assert_eq!(is_root_domain("smtp://sub2.sub1.www.instagram.com", ClaimType::WebServiceAccount), false);
-        assert_eq!(is_root_domain("www.instagram.com", ClaimType::WebServiceAccount), true);
-        assert_eq!(is_root_domain("sub1.instagram.com", ClaimType::WebServiceAccount), false);
+        assert_eq!(
+            is_root_domain("http://instagram.com", ClaimType::WebServiceAccount),
+            true
+        );
+        assert_eq!(
+            is_root_domain("https://instagram.com", ClaimType::WebServiceAccount),
+            true
+        );
+        assert_eq!(
+            is_root_domain("https://www.instagram.com", ClaimType::WebServiceAccount),
+            true
+        );
+        assert_eq!(
+            is_root_domain(
+                "https://sub2.sub1.www.instagram.com",
+                ClaimType::WebServiceAccount
+            ),
+            false
+        );
+        assert_eq!(
+            is_root_domain("ftp://www.instagram.com", ClaimType::WebServiceAccount),
+            true
+        );
+        assert_eq!(
+            is_root_domain("ftp://instagram.com", ClaimType::WebServiceAccount),
+            true
+        );
+        assert_eq!(
+            is_root_domain(
+                "ftp://sub2.sub1.www.instagram.com",
+                ClaimType::WebServiceAccount
+            ),
+            false
+        );
+        assert_eq!(
+            is_root_domain(
+                "smtp://sub2.sub1.www.instagram.com",
+                ClaimType::WebServiceAccount
+            ),
+            false
+        );
+        assert_eq!(
+            is_root_domain("www.instagram.com", ClaimType::WebServiceAccount),
+            true
+        );
+        assert_eq!(
+            is_root_domain("sub1.instagram.com", ClaimType::WebServiceAccount),
+            false
+        );
         assert_eq!(is_root_domain("urauth://file/", ClaimType::File), true);
     }
 
@@ -1217,39 +1267,29 @@ mod tests {
             .is_root()
     }
 
-    // cargo t -p pallet-urauth --lib -- types::tests::uri_part_eq_works --exact --nocapture 
+    // cargo t -p pallet-urauth --lib -- types::tests::uri_part_eq_works --exact --nocapture
     #[test]
     fn uri_part_eq_works() {
-        let uri_part1 = URIPart::new(
-            "https://".into(),
-            None,
-            Some("instagram.com".into()),
-            None
-        );
-        let uri_part2 = URIPart::new(
-            "https://".into(),
-            None,
-            Some("instagram.com".into()),
-            None
-        );
+        let uri_part1 = URIPart::new("https://".into(), None, Some("instagram.com".into()), None);
+        let uri_part2 = URIPart::new("https://".into(), None, Some("instagram.com".into()), None);
         assert!(uri_part1 == uri_part2);
         let uri_part3 = URIPart::new(
             "https://".into(),
             None,
             Some("instagram.com".into()),
-            Some("/coco".into())
+            Some("/coco".into()),
         );
         let uri_part4 = URIPart::new(
             "https://".into(),
             None,
             Some("instagram.com".into()),
-            Some("/coco/1/2/3".into())
+            Some("/coco/1/2/3".into()),
         );
         let uri_part_any_path = URIPart::new(
             "https://".into(),
             None,
             Some("instagram.com".into()),
-            Some("/*".into())
+            Some("/*".into()),
         );
         assert!(uri_part3 == uri_part_any_path);
         assert!(uri_part4 == uri_part_any_path);
@@ -1266,26 +1306,28 @@ mod tests {
             .find(|(field, _)| field.iter().copied().eq(field_name.chars()))
             .unwrap();
         match json_value {
-            lite_json::JsonValue::String(v) => Some(v.iter().map(|c| *c as u8).collect::<Vec<u8>>()),
+            lite_json::JsonValue::String(v) => {
+                Some(v.iter().map(|c| *c as u8).collect::<Vec<u8>>())
+            }
             lite_json::JsonValue::Object(v) => find_json_value(v.clone(), sub, None),
             _ => None,
         }
     }
-    
+
     fn account_id_from_did_raw(mut raw: Vec<u8>) -> AccountId32 {
         let actual_owner_did: Vec<u8> = raw.drain(raw.len() - 48..raw.len()).collect();
         let mut output = bs58::decode(actual_owner_did).into_vec().unwrap();
-                                        let temp: Vec<u8> = output.drain(1..33).collect();
+        let temp: Vec<u8> = output.drain(1..33).collect();
         let mut raw_account_id = [0u8; 32];
         let buf = &temp[..raw_account_id.len()];
         raw_account_id.copy_from_slice(buf);
         raw_account_id.into()
     }
-    
+
     #[test]
     fn json_parse_works() {
         use lite_json::{json_parser::parse_json, JsonValue};
-    
+
         let json_string = r#"
             {
                 "domain" : "website1.com",
@@ -1301,7 +1343,7 @@ mod tests {
                 }
             } 
         "#;
-    
+
         let json_data = parse_json(json_string).expect("Invalid!");
         let mut domain: Vec<u8> = vec![];
         let mut admin_did: Vec<u8> = vec![];
@@ -1309,7 +1351,7 @@ mod tests {
         let mut timestamp: Vec<u8> = vec![];
         let mut proof_type: Vec<u8> = vec![];
         let mut proof: Vec<u8> = vec![];
-    
+
         match json_data {
             JsonValue::Object(obj_value) => {
                 domain = find_json_value(obj_value.clone(), "domain", None).unwrap();
@@ -1317,18 +1359,25 @@ mod tests {
                 challenge = find_json_value(obj_value.clone(), "challenge", None).unwrap();
                 timestamp = find_json_value(obj_value.clone(), "timestamp", None).unwrap();
                 proof_type = find_json_value(obj_value.clone(), "proof", Some("type")).unwrap();
-                proof = find_json_value(obj_value.clone(), "proof".into(), Some("proofValue")).unwrap();
+                proof =
+                    find_json_value(obj_value.clone(), "proof".into(), Some("proofValue")).unwrap();
             }
             _ => {}
         }
         assert_eq!(domain, "website1.com".as_bytes().to_vec());
-        assert_eq!(admin_did, "did:infra:ua:5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV"
-            .as_bytes()
-            .to_vec());
+        assert_eq!(
+            admin_did,
+            "did:infra:ua:5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV"
+                .as_bytes()
+                .to_vec()
+        );
         assert_eq!(challenge, "__random_challenge_value__".as_bytes().to_vec());
         assert_eq!(timestamp, "2023-07-28T10:17:21Z".as_bytes().to_vec());
         assert_eq!(proof_type, "Ed25519Signature2020".as_bytes().to_vec());
-        assert_eq!(proof, "gweEDz58DAdFfa9.....CrfFPP2oumHKtz".as_bytes().to_vec());
+        assert_eq!(
+            proof,
+            "gweEDz58DAdFfa9.....CrfFPP2oumHKtz".as_bytes().to_vec()
+        );
         let account_id32 = account_id_from_did_raw(admin_did);
         println!("AccountId32 => {:?}", account_id32);
     }

--- a/pallets/urauth/src/types.rs
+++ b/pallets/urauth/src/types.rs
@@ -731,7 +731,6 @@ impl<T: Config> Parser<T> for URAuthParser {
             .map_err(|_| Error::<T>::ErrorConvertToString)?;
         match ada_url::Url::parse(maybe_root, None) {
             Ok(url) => {
-                sp_std::if_std! { println!("{:?}", url); }
                 let mut root: &str = url.host();
                 let mut protocol: Option<&str> = None;
                 if url.scheme_type() != ada_url::SchemeType::Http && 
@@ -749,7 +748,6 @@ impl<T: Config> Parser<T> for URAuthParser {
                         sp_std::if_std! { println!("{:?}", e) }
                         Error::<T>::ErrorOnParse
                     })?;
-                sp_std::if_std! { println!("Prefix => {:?}", domain.prefix()); }
                 if domain.prefix() != None 
                     && domain.prefix() != Some("www") {
                     return Err(Error::<T>::NotBaseURI.into());
@@ -769,20 +767,14 @@ impl<T: Config> Parser<T> for URAuthParser {
                     .map_err(|_| Error::<T>::OverMaxSize)?
                 )
             },
-            Err(e) => { 
-                sp_std::if_std! { println!("{:?}", e) }
+            Err(_e) => { 
                 let mut root = maybe_root;
                 match addr::parse_domain_name(root) {
                     Ok(domain) => {
                         root = domain.root().ok_or(Error::<T>::ErrorOnParse)?;
                     },
-                    Err(e) => {
-                        sp_std::if_std! { println!("{:?}", e) }
-                        root = root
-                            .split('/')
-                            .collect::<Vec<&str>>()
-                            .first()
-                            .ok_or(Error::<T>::ErrorOnParse)?;
+                    Err(_e) => {
+                        return Err(Error::<T>::NotBaseURI.into())
                     }
                 }
                 Ok(root

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -44,8 +44,10 @@ frame-try-runtime = { git = "https://github.com/InfraBlockchain/infra-substrate"
 pallet-aura = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, branch = "master" }
 pallet-authorship = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, branch = "master" }
 pallet-balances = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, branch = "master" }
+pallet-preimage = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, branch = "master" }
 pallet-session = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, branch = "master" }
 pallet-system-token = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, branch = "master" }
+pallet-scheduler = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, branch = "master" }
 pallet-sudo = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, branch = "master" }
 pallet-timestamp = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, branch = "master" }
 pallet-transaction-payment = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, branch = "master" }
@@ -105,6 +107,8 @@ std = [
 	"frame-system-rpc-runtime-api/std",
 	"frame-system/std",
 	"frame-system-benchmarking/std",
+	"pallet-scheduler/std",
+	"pallet-preimage/std",
 	"pallet-assets/std",
 	"pallet-asset-link/std",
 	"xcm-primitives/std",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -24,7 +24,7 @@ scale-info = { version = "2.3.1", default-features = false, features = ["derive"
 smallvec = "1.10.0"
 
 # Local
-pallet-urauth = { version = "0.1.0", default-features = false, path = "../pallets/urauth" }
+pallet-urauth = { version = "0.1.1", default-features = false, path = "../pallets/urauth" }
 pallet-urauth-runtime-api = { version = "0.1.0", default-features = false, path = "../pallets/urauth/runtime-api" }
 
 # Substrate

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -537,10 +537,11 @@ parameter_types! {
 
 impl pallet_urauth::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type AuthorizedOrigin = EnsureRoot<AccountId>;
+    type URAuthParser = pallet_urauth::URAuthParser;
     type UnixTime = Timestamp;
     type MaxOracleMembers = MaxOracleMembers;
     type MaxURIByOracle = MaxURIByOracle;
+    type AuthorizedOrigin = EnsureRoot<AccountId>;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -531,39 +531,39 @@ impl system_token_aggregator::Config for Runtime {
 }
 
 parameter_types! {
-	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(80) *
-		RuntimeBlockWeights::get().max_block;
+    pub MaximumSchedulerWeight: Weight = Perbill::from_percent(80) *
+        RuntimeBlockWeights::get().max_block;
 }
 
 impl pallet_scheduler::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeOrigin = RuntimeOrigin;
-	type PalletsOrigin = OriginCaller;
-	type RuntimeCall = RuntimeCall;
-	type MaximumWeight = MaximumSchedulerWeight;
-	type ScheduleOrigin = EnsureRoot<AccountId>;
-	#[cfg(feature = "runtime-benchmarks")]
-	type MaxScheduledPerBlock = ConstU32<512>;
-	#[cfg(not(feature = "runtime-benchmarks"))]
-	type MaxScheduledPerBlock = ConstU32<50>;
-	type WeightInfo = pallet_scheduler::weights::SubstrateWeight<Runtime>;
-	type OriginPrivilegeCmp = frame_support::traits::EqualPrivilegeOnly;
-	type Preimages = Preimage;
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeOrigin = RuntimeOrigin;
+    type PalletsOrigin = OriginCaller;
+    type RuntimeCall = RuntimeCall;
+    type MaximumWeight = MaximumSchedulerWeight;
+    type ScheduleOrigin = EnsureRoot<AccountId>;
+    #[cfg(feature = "runtime-benchmarks")]
+    type MaxScheduledPerBlock = ConstU32<512>;
+    #[cfg(not(feature = "runtime-benchmarks"))]
+    type MaxScheduledPerBlock = ConstU32<50>;
+    type WeightInfo = pallet_scheduler::weights::SubstrateWeight<Runtime>;
+    type OriginPrivilegeCmp = frame_support::traits::EqualPrivilegeOnly;
+    type Preimages = Preimage;
 }
 
 parameter_types! {
-	pub const PreimageBaseDeposit: Balance = MILLIUNIT;
-	// One cent: $10,000 / MB
-	pub const PreimageByteDeposit: Balance = MICROUNIT;
+    pub const PreimageBaseDeposit: Balance = MILLIUNIT;
+    // One cent: $10,000 / MB
+    pub const PreimageByteDeposit: Balance = MICROUNIT;
 }
 
 impl pallet_preimage::Config for Runtime {
-	type WeightInfo = pallet_preimage::weights::SubstrateWeight<Runtime>;
-	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
-	type ManagerOrigin = EnsureRoot<AccountId>;
-	type BaseDeposit = PreimageBaseDeposit;
-	type ByteDeposit = PreimageByteDeposit;
+    type WeightInfo = pallet_preimage::weights::SubstrateWeight<Runtime>;
+    type RuntimeEvent = RuntimeEvent;
+    type Currency = Balances;
+    type ManagerOrigin = EnsureRoot<AccountId>;
+    type BaseDeposit = PreimageBaseDeposit;
+    type ByteDeposit = PreimageByteDeposit;
 }
 
 parameter_types! {
@@ -625,10 +625,10 @@ construct_runtime!(
 
         // Governance
         // Preimage registrar.
-		Preimage: pallet_preimage::{Pallet, Call, Storage, Event<T>} = 40,
+        Preimage: pallet_preimage::{Pallet, Call, Storage, Event<T>} = 40,
 
         // System scheduler.
-		Scheduler: pallet_scheduler::{Pallet, Call, Storage, Event<T>} = 41,
+        Scheduler: pallet_scheduler::{Pallet, Call, Storage, Event<T>} = 41,
     }
 );
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -532,6 +532,7 @@ impl system_token_aggregator::Config for Runtime {
 
 parameter_types! {
     pub const MaxOracleMembers: u32 = 10;
+    pub const MaxURIByOracle: u32 = 100;
 }
 
 impl pallet_urauth::Config for Runtime {
@@ -539,6 +540,7 @@ impl pallet_urauth::Config for Runtime {
     type AuthorizedOrigin = EnsureRoot<AccountId>;
     type UnixTime = Timestamp;
     type MaxOracleMembers = MaxOracleMembers;
+    type MaxURIByOracle = MaxURIByOracle;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -531,8 +531,46 @@ impl system_token_aggregator::Config for Runtime {
 }
 
 parameter_types! {
+	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(80) *
+		RuntimeBlockWeights::get().max_block;
+}
+
+impl pallet_scheduler::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+	type PalletsOrigin = OriginCaller;
+	type RuntimeCall = RuntimeCall;
+	type MaximumWeight = MaximumSchedulerWeight;
+	type ScheduleOrigin = EnsureRoot<AccountId>;
+	#[cfg(feature = "runtime-benchmarks")]
+	type MaxScheduledPerBlock = ConstU32<512>;
+	#[cfg(not(feature = "runtime-benchmarks"))]
+	type MaxScheduledPerBlock = ConstU32<50>;
+	type WeightInfo = pallet_scheduler::weights::SubstrateWeight<Runtime>;
+	type OriginPrivilegeCmp = frame_support::traits::EqualPrivilegeOnly;
+	type Preimages = Preimage;
+}
+
+parameter_types! {
+	pub const PreimageBaseDeposit: Balance = MILLIUNIT;
+	// One cent: $10,000 / MB
+	pub const PreimageByteDeposit: Balance = MICROUNIT;
+}
+
+impl pallet_preimage::Config for Runtime {
+	type WeightInfo = pallet_preimage::weights::SubstrateWeight<Runtime>;
+	type RuntimeEvent = RuntimeEvent;
+	type Currency = Balances;
+	type ManagerOrigin = EnsureRoot<AccountId>;
+	type BaseDeposit = PreimageBaseDeposit;
+	type ByteDeposit = PreimageByteDeposit;
+}
+
+parameter_types! {
     pub const MaxOracleMembers: u32 = 10;
     pub const MaxURIByOracle: u32 = 100;
+    pub const VerificationPeriod: BlockNumber = 100;
+    pub const MaxRequest: u32 = 100;
 }
 
 impl pallet_urauth::Config for Runtime {
@@ -541,6 +579,8 @@ impl pallet_urauth::Config for Runtime {
     type UnixTime = Timestamp;
     type MaxOracleMembers = MaxOracleMembers;
     type MaxURIByOracle = MaxURIByOracle;
+    type VerificationPeriod = VerificationPeriod;
+    type MaxRequest = MaxRequest;
     type AuthorizedOrigin = EnsureRoot<AccountId>;
 }
 
@@ -582,6 +622,13 @@ construct_runtime!(
         AssetLink: pallet_asset_link = 34,
         SystemTokenAggregator: system_token_aggregator = 35,
         SystemToken: pallet_system_token = 36,
+
+        // Governance
+        // Preimage registrar.
+		Preimage: pallet_preimage::{Pallet, Call, Storage, Event<T>} = 40,
+
+        // System scheduler.
+		Scheduler: pallet_scheduler::{Pallet, Call, Storage, Event<T>} = 41,
     }
 );
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -537,7 +537,7 @@ parameter_types! {
 
 impl pallet_urauth::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type URAuthParser = pallet_urauth::URAuthParser;
+    type URAuthParser = pallet_urauth::URAuthParser<Self>;
     type UnixTime = Timestamp;
     type MaxOracleMembers = MaxOracleMembers;
     type MaxURIByOracle = MaxURIByOracle;


### PR DESCRIPTION
## Overview
해당 PR 은 `URAuthTree` 에 등록되는 URI 에 대한 추가적인 검증 과정을 포함한다. 

TL;DR
1. 논리적으로 _Tree_ 구조를 이루어 저장되어 있는 `URAuthTree` 에 `URI` 를 등록할 때, `URIByOracle` 에 의해 관리되고 있는 `URI` 를 제외하고는 상위 노드의 owner 체크를 통해 `URI` 를 등록. 여기서, `Parser` trait 를 이용하여 등록 요청된 `URI` 를 파싱한 후, 상위 노드를 체크하는 식으로 `Tree` 구조 구현.
2. `URAuthTree` 에 등록 요청된 `URI` 에 대해 데드 라인을 두어 특정 블록 안에 claim 이 안될 시, 폐기.
3. Signature(proof) 생성 시, nonce 를 추가하여 재사용을 방지.
4. Storage 에 저장되는 각 타입들 `BoundedVec` 적용

## Changes

### URI Registration Rule
1. `http://` `https://` 는 같은 것으로 간주하며 별도의 scheme 명시가 되어 있지 않으면 `https://` 로 고정. 또한 별도의 sub_domain 이 명시되어 있지 않으면 `www.` 으로 고정.
2. `ClaimType::Contents` 의 scheme 은 `urauth://` 로 고정.
3. Root의 경우,
- `ClaimType::Domain`: `{protocol:}//*.*`
- `ClaimType::Contents`: `urauth://*/{cid}`
4. `ClaimType::Domain` 의 경우, `host` 가 `None` 일시 유효하지 않은 URI 로 간주.

### Types

`ClaimType`
- `URAuthTree` 에 등록하는 `URI` 의 타입.
- 해당 타입별 파싱 방법 및 root 판별법을 따로 정의하고 있다.
```rust
pub enum ClaimType {
    Domain,
    Contents
}
```

`URIPart`
- `URI` 를 파싱하고 난 후, 해당 데이터 구조로 정의된다.
- **_Careful Review Required_**: 
    - `partial_eq` 직접 impl 하는 부분
    - `is_root()` 판별하는 부분
```rust
pub struct URIPart {
    pub scheme: Vec<u8>,
    pub sub_domain: Option<Vec<u8>>,
    pub host: Option<Vec<u8>>,
    pub path: Option<Vec<u8>>,
}
```

`URAuthParser`
- `challenge.json` 및 `URI` 를 파싱하는 타입. 
- `Parser` trait 를 impl 하고 있다.
```rust
pub struct URAuthParser<T>(PhantomData<T>);

pub trait Parser<T: Config> {
    type URI;
    type Part: Clone + sp_std::fmt::Debug + PartialEq;
    type ClaimType;
    type ChallengeValue: Default;

    fn parse_uri(raw_uri: &Vec<u8>, claim_type: &ClaimType) -> Result<Self::Part, DispatchError>;

    fn parse_parent_uris(
        raw_uri: &Vec<u8>,
        claim_type: &ClaimType,
    ) -> Result<Vec<URI>, DispatchError>;

    fn parse_challenge_json() -> Result<Self::ChallengeValue, DispatchError> {
        Ok(Default::default())
    }
}
```

### Storage
 
`URIByOracle`
- Oracle 에 의해 검증 과정을 거치고 `URAuthTree` 에 등록되는 URI 목록
```rust
pub type URIByOracle<T: Config> = StorageValue<_, Vec<URIPart>, OptionQuery>;
```

`RequestedURIs`
- 해당 블록에 요청된 URI 목록
```rust
pub type RequestedURIs<T: Config> =
        StorageMap<_, Twox128, BlockNumberFor<T>, BoundedVec<URI, T::MaxRequest>>;
```

`DIDs`
- DID 의 상태값을 관리하기 위한 스토리지(e.g nonce)
```rust
pub type DIDs<T: Config> = StorageMap<_, Twox128, T::AccountId, DidDetails<T>>;
```

### Extrinsics

`add_uri_by_oracles`, `remove_uri_by_oracles`
- `URIByOracle` 의 상태를 변경하기 위한 extrinsics


